### PR TITLE
ci: switch NPM publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,11 +38,9 @@ jobs:
         node --version
         yarn --version
     - name: Publish NPM
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
         make build_nodejs
-        npm publish --access public sdk/nodejs/bin
+        npm publish --access public --provenance sdk/nodejs/bin
         git checkout -f sdk/nodejs/package.json
     - name: Set PreRelease Version
       run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- Replace `NPM_TOKEN` secret with GitHub Actions OIDC provenance
- Add `id-token: write` permission to release job
- Add `--provenance` flag to `npm publish`

## Required setup on npmjs.com

Before merging, the `@rootly/pulumi` package must be configured to trust this GitHub repo:

1. Go to https://www.npmjs.com/package/@rootly/pulumi/access
2. Under "Publishing access" → "Trusted publishing"
3. Add: repository `rootlyhq/pulumi-rootly`, workflow `release.yml`, environment (leave blank)

## Test plan

- [ ] Configure trusted publishing on npmjs.com
- [ ] Merge and re-tag v3.1.0