### PR TITLE
fix: restore NODE_AUTH_TOKEN for NPM publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
         node --version
         yarn --version
     - name: Publish NPM
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
         make build_nodejs
         npm publish --access public --provenance sdk/nodejs/bin


### PR DESCRIPTION
## Summary

- Restore `NODE_AUTH_TOKEN` env var for npm publish step
- `--provenance` is attestation only, not auth replacement
- `setup-node` writes `.npmrc` with `${NODE_AUTH_TOKEN}` placeholder — needs the env var

## Test plan

- [ ] Merge, re-tag v3.1.0, verify npm publish succeeds