### PR TITLE
ci: fix OIDC trusted publishing for NPM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,16 +63,10 @@ jobs:
       run: |
         corepack enable
         yarn set version 1.22.22
-    - name: Verify Node.js and Yarn versions
-      run: |
-        node --version
-        yarn --version
     - name: Publish NPM
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
         make build_nodejs
-        npm publish --access public --provenance sdk/nodejs/bin
+        npm publish --access public sdk/nodejs/bin
         git checkout -f sdk/nodejs/package.json
     strategy:
       fail-fast: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
       with:
         node-version: '22.x'
         registry-url: 'https://registry.npmjs.org'
+    - name: Upgrade npm for OIDC trusted publishing
+      run: npm install -g npm@latest
     - name: Setup Yarn
       run: |
         corepack enable
@@ -66,7 +68,7 @@ jobs:
     - name: Publish NPM
       run: |
         make build_nodejs
-        npm publish --access public sdk/nodejs/bin
+        npm publish --access public --provenance sdk/nodejs/bin
         git checkout -f sdk/nodejs/package.json
     strategy:
       fail-fast: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         repo: pulumi/pulumictl
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '22.x'
+        node-version: '24.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Upgrade npm for OIDC trusted publishing
       run: npm install -g npm@latest


### PR DESCRIPTION
## Summary

- Upgrade Node.js from 22.x to 24.x
- Add explicit `npm install -g npm@latest` — OIDC trusted publishing requires npm 11.5.1+, Node 24.x only ships 11.3.0
- Remove `NODE_AUTH_TOKEN` env var — not needed with OIDC trusted publishing
- Restore `--provenance` flag for Sigstore supply chain attestation
- Remove debug "Verify versions" step

## Context

Node 22.x ships npm 10.9.x which has no OIDC support at all. Node 24.x ships npm 11.3.0 which is close but still below the 11.5.1 minimum. The explicit npm upgrade step bridges the gap until a Node version ships with npm 11.5.1+ out of the box.

## Test plan

- [ ] Merge and tag a new release
- [ ] Verify npm-publish job succeeds with OIDC-only auth (no `NPM_TOKEN` secret)
- [ ] Verify provenance attestation appears on npmjs.com package page