### PR TITLE
ci: add workflow_dispatch trigger for manual releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ on:
   push:
     tags:
       - v*.*.*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to release (e.g. v3.1.0)'
+        required: true
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
@@ -14,6 +19,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.tag || github.ref }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -45,6 +52,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.tag || github.ref }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger with `tag` input to release workflow
- Both `github-release` and `npm-publish` jobs checkout the specified tag ref
- Falls back to `github.ref` for normal tag-push triggers

Allows re-running releases from GitHub Actions UI without deleting/re-pushing tags.

## Usage

Actions → release → Run workflow → enter tag (e.g. `v3.1.0`)

## Test plan

- [ ] Merge and trigger manually with an existing tag
- [ ] Verify both jobs run against correct tag ref