### PR TITLE
fix: publish tar.gz plugin archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,8 @@ builds:
     main: ./cmd/pulumi-resource-rootly/
 archives:
   - id: archive
-    format: zip
+    formats:
+      - tar.gz
     name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}'
     files:
       - 'none*'


### PR DESCRIPTION
## Summary
- Change GoReleaser plugin archives from zip to tar.gz so Pulumi can download provider plugins from GitHub releases.
- Use the non-deprecated `formats` field for GoReleaser v2 archive configuration.

## Verification
- Reproduced `pulumi plugin install` requesting `pulumi-resource-rootly-v3.1.0-darwin-arm64.tar.gz` from the v3.1.0 release.
- Confirmed current v3.1.0 release assets are zip archives, causing 404s.
- Ran `go run github.com/goreleaser/goreleaser/v2@latest check` successfully.