### PR TITLE
fix plugin download URL

### DIFF
--- a/provider/cmd/pulumi-resource-rootly/schema.json
+++ b/provider/cmd/pulumi-resource-rootly/schema.json
@@ -12,7 +12,7 @@
     "attribution": "This Pulumi package is based on the [`rootly` Terraform Provider](https://github.com/rootlyhq/terraform-provider-rootly).",
     "repository": "https://github.com/rootlyhq/pulumi-rootly",
     "logoUrl": "https://raw.githubusercontent.com/rootlyhq/pulumi-rootly/master/logos/rootly.svg",
-    "pluginDownloadURL": "https://github.com/rootlyhq/pulumi-rootly/releases/v${VERSION}",
+    "pluginDownloadURL": "https://github.com/rootlyhq/pulumi-rootly/releases/download/v${VERSION}",
     "publisher": "rootlyhq",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -125,8 +125,8 @@ func Provider() tfbridge.ProviderInfo {
 		LogoURL: "https://raw.githubusercontent.com/rootlyhq/pulumi-rootly/master/logos/rootly.svg",
 		// PluginDownloadURL is an optional URL used to download the Provider
 		// for use in Pulumi programs
-		// e.g https://github.com/org/pulumi-provider-name/releases/
-		PluginDownloadURL: "https://github.com/rootlyhq/pulumi-rootly/releases/v${VERSION}",
+		// e.g https://github.com/org/pulumi-provider-name/releases/download/v${VERSION}
+		PluginDownloadURL: "https://github.com/rootlyhq/pulumi-rootly/releases/download/v${VERSION}",
 		Description:       "A Pulumi package for creating and managing rootly cloud resources.",
 		// category/cloud tag helps with categorizing the package in the Pulumi Registry.
 		// For all available categories, see `Keywords` in

--- a/sdk/go/rootly/internal/pulumiUtilities.go
+++ b/sdk/go/rootly/internal/pulumiUtilities.go
@@ -164,7 +164,7 @@ func callPlainInner(
 // PkgResourceDefaultOpts provides package level defaults to pulumi.OptionResource.
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
-	defaults = append(defaults, pulumi.PluginDownloadURL("https://github.com/rootlyhq/pulumi-rootly/releases/v${VERSION}"))
+	defaults = append(defaults, pulumi.PluginDownloadURL("https://github.com/rootlyhq/pulumi-rootly/releases/download/v${VERSION}"))
 	version := SdkVersion
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
@@ -175,7 +175,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 // PkgInvokeDefaultOpts provides package level defaults to pulumi.OptionInvoke.
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
-	defaults = append(defaults, pulumi.PluginDownloadURL("https://github.com/rootlyhq/pulumi-rootly/releases/v${VERSION}"))
+	defaults = append(defaults, pulumi.PluginDownloadURL("https://github.com/rootlyhq/pulumi-rootly/releases/download/v${VERSION}"))
 	version := SdkVersion
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))

--- a/sdk/go/rootly/pulumi-plugin.json
+++ b/sdk/go/rootly/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "rootly",
-  "server": "https://github.com/rootlyhq/pulumi-rootly/releases/v${VERSION}"
+  "server": "https://github.com/rootlyhq/pulumi-rootly/releases/download/v${VERSION}"
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -24,6 +24,6 @@
     "pulumi": {
         "resource": true,
         "name": "rootly",
-        "server": "https://github.com/rootlyhq/pulumi-rootly/releases/v${VERSION}"
+        "server": "https://github.com/rootlyhq/pulumi-rootly/releases/download/v${VERSION}"
     }
 }

--- a/sdk/nodejs/utilities.ts
+++ b/sdk/nodejs/utilities.ts
@@ -53,7 +53,7 @@ export function getVersion(): string {
 
 /** @internal */
 export function resourceOptsDefaults(): any {
-    return { version: getVersion(), pluginDownloadURL: "https://github.com/rootlyhq/pulumi-rootly/releases/v${VERSION}" };
+    return { version: getVersion(), pluginDownloadURL: "https://github.com/rootlyhq/pulumi-rootly/releases/download/v${VERSION}" };
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary
- Use GitHub's release asset download URL for Pulumi plugin installs.
- Update generated SDK plugin metadata.

## Verification
- `pulumi plugin install resource rootly v3.1.2 --server https://github.com/rootlyhq/pulumi-rootly/releases/download/v3.1.2 --reinstall`