### PR TITLE
chore: migrate to TF provider v5.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ tfgen:: install_plugins
 	(cd provider && VERSION=$(VERSION) go generate cmd/${PROVIDER}/main.go)
 
 update_provider::
-	(cd provider && go get -u github.com/rootlyhq/terraform-provider-rootly/v2@master)
+	(cd provider && go get -u github.com/rootlyhq/terraform-provider-rootly/v5@latest)
 	(cd provider && go mod tidy)
 
 provider:: tfgen install_plugins # build the provider binary

--- a/provider/cmd/pulumi-resource-rootly/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-rootly/bridge-metadata.json
@@ -3521,7 +3521,35 @@
                 "majorVersion": 3,
                 "fields": {
                     "services": {
-                        "maxItemsOne": false
+                        "maxItemsOne": false,
+                        "elem": {
+                            "fields": {
+                                "environment_ids": {
+                                    "maxItemsOne": false
+                                },
+                                "notify_emails": {
+                                    "maxItemsOne": false
+                                },
+                                "owner_group_ids": {
+                                    "maxItemsOne": false
+                                },
+                                "owner_user_ids": {
+                                    "maxItemsOne": false
+                                },
+                                "properties": {
+                                    "maxItemsOne": false
+                                },
+                                "service_ids": {
+                                    "maxItemsOne": false
+                                },
+                                "slack_aliases": {
+                                    "maxItemsOne": false
+                                },
+                                "slack_channels": {
+                                    "maxItemsOne": false
+                                }
+                            }
+                        }
                     }
                 }
             },

--- a/provider/cmd/pulumi-resource-rootly/schema.json
+++ b/provider/cmd/pulumi-resource-rootly/schema.json
@@ -1380,17 +1380,9 @@
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "allDay",
                         "endTime",
-                        "friday",
-                        "monday",
                         "position",
-                        "saturday",
-                        "startTime",
-                        "sunday",
-                        "thursday",
-                        "tuesday",
-                        "wednesday"
+                        "startTime"
                     ]
                 }
             }
@@ -2040,23 +2032,23 @@
             "properties": {
                 "incidentActionItemCondition": {
                     "type": "string",
-                    "description": "Value must be one off `ALL`, `ANY`, `NONE`.\n"
+                    "description": "Value must be one of `ALL`, `ANY`, `NONE`.\n"
                 },
                 "incidentActionItemConditionGroup": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentActionItemConditionKind": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentActionItemConditionPriority": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentActionItemConditionStatus": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentActionItemGroupIds": {
                     "type": "array",
@@ -2087,72 +2079,79 @@
                 },
                 "incidentCondition": {
                     "type": "string",
-                    "description": "Value must be one off `ALL`, `ANY`, `NONE`.\n"
+                    "description": "Value must be one of `ALL`, `ANY`, `NONE`.\n"
                 },
                 "incidentConditionAcknowledgedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionDetectedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionEnvironment": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionFunctionality": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionGroup": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionIncidentRoles": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionIncidentType": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionKind": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionMitigatedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionResolvedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionService": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionSeverity": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionStartedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionStatus": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionSubStatus": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionSummary": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionVisibility": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionalInactivity": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `IS`.\n"
                 },
                 "incidentInactivityDuration": {
                     "type": "string",
@@ -2180,7 +2179,7 @@
                 },
                 "triggerType": {
                     "type": "string",
-                    "description": "Value must be one off \u003cspan pulumi-lang-nodejs=\"`actionItem`\" pulumi-lang-dotnet=\"`ActionItem`\" pulumi-lang-go=\"`actionItem`\" pulumi-lang-python=\"`action_item`\" pulumi-lang-yaml=\"`actionItem`\" pulumi-lang-java=\"`actionItem`\"\u003e`actionItem`\u003c/span\u003e.\n"
+                    "description": "Value must be one of \u003cspan pulumi-lang-nodejs=\"`actionItem`\" pulumi-lang-dotnet=\"`ActionItem`\" pulumi-lang-go=\"`actionItem`\" pulumi-lang-python=\"`action_item`\" pulumi-lang-yaml=\"`actionItem`\" pulumi-lang-java=\"`actionItem`\"\u003e`actionItem`\u003c/span\u003e.\n"
                 },
                 "triggers": {
                     "type": "array",
@@ -2218,11 +2217,11 @@
             "properties": {
                 "alertCondition": {
                     "type": "string",
-                    "description": "Value must be one off `ALL`, `ANY`, `NONE`.\n"
+                    "description": "Value must be one of `ALL`, `ANY`, `NONE`.\n"
                 },
                 "alertConditionLabel": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "alertConditionLabelUseRegexp": {
                     "type": "boolean",
@@ -2230,7 +2229,7 @@
                 },
                 "alertConditionPayload": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "alertConditionPayloadUseRegexp": {
                     "type": "boolean",
@@ -2238,7 +2237,7 @@
                 },
                 "alertConditionSource": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "alertConditionSourceUseRegexp": {
                     "type": "boolean",
@@ -2246,7 +2245,7 @@
                 },
                 "alertConditionStatus": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "alertConditionStatusUseRegexp": {
                     "type": "boolean",
@@ -2254,7 +2253,7 @@
                 },
                 "alertConditionUrgency": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "alertFieldConditions": {
                     "type": "array",
@@ -2301,7 +2300,7 @@
                 },
                 "triggerType": {
                     "type": "string",
-                    "description": "Value must be one off \u003cspan pulumi-lang-nodejs=\"`alert`\" pulumi-lang-dotnet=\"`Alert`\" pulumi-lang-go=\"`alert`\" pulumi-lang-python=\"`alert`\" pulumi-lang-yaml=\"`alert`\" pulumi-lang-java=\"`alert`\"\u003e`alert`\u003c/span\u003e.\n"
+                    "description": "Value must be one of \u003cspan pulumi-lang-nodejs=\"`alert`\" pulumi-lang-dotnet=\"`Alert`\" pulumi-lang-go=\"`alert`\" pulumi-lang-python=\"`alert`\" pulumi-lang-yaml=\"`alert`\" pulumi-lang-java=\"`alert`\"\u003e`alert`\u003c/span\u003e.\n"
                 },
                 "triggers": {
                     "type": "array",
@@ -2393,76 +2392,83 @@
             "properties": {
                 "incidentCondition": {
                     "type": "string",
-                    "description": "Value must be one off `ALL`, `ANY`, `NONE`.\n"
+                    "description": "Value must be one of `ALL`, `ANY`, `NONE`.\n"
                 },
                 "incidentConditionAcknowledgedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionCause": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionDetectedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionEnvironment": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionFunctionality": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionGroup": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionIncidentRoles": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionIncidentType": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionKind": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionMitigatedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionResolvedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionService": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionSeverity": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionStartedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionStatus": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionSubStatus": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionSummary": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionVisibility": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionalInactivity": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `IS`.\n"
                 },
                 "incidentInactivityDuration": {
                     "type": "string",
@@ -2477,7 +2483,7 @@
                 },
                 "incidentPostMortemConditionCause": {
                     "type": "string",
-                    "description": "[DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "[DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentStatuses": {
                     "type": "array",
@@ -2494,7 +2500,7 @@
                 },
                 "triggerType": {
                     "type": "string",
-                    "description": "Value must be one off \u003cspan pulumi-lang-nodejs=\"`incident`\" pulumi-lang-dotnet=\"`Incident`\" pulumi-lang-go=\"`incident`\" pulumi-lang-python=\"`incident`\" pulumi-lang-yaml=\"`incident`\" pulumi-lang-java=\"`incident`\"\u003e`incident`\u003c/span\u003e.\n"
+                    "description": "Value must be one of \u003cspan pulumi-lang-nodejs=\"`incident`\" pulumi-lang-dotnet=\"`Incident`\" pulumi-lang-go=\"`incident`\" pulumi-lang-python=\"`incident`\" pulumi-lang-yaml=\"`incident`\" pulumi-lang-java=\"`incident`\"\u003e`incident`\u003c/span\u003e.\n"
                 },
                 "triggers": {
                     "type": "array",
@@ -2528,76 +2534,83 @@
             "properties": {
                 "incidentCondition": {
                     "type": "string",
-                    "description": "Value must be one off `ALL`, `ANY`, `NONE`.\n"
+                    "description": "Value must be one of `ALL`, `ANY`, `NONE`.\n"
                 },
                 "incidentConditionAcknowledgedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionCause": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionDetectedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionEnvironment": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionFunctionality": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionGroup": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionIncidentRoles": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionIncidentType": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionKind": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionMitigatedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionResolvedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionService": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionSeverity": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionStartedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionStatus": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionSubStatus": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionSummary": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `SET`, `UNSET`.\n"
                 },
                 "incidentConditionVisibility": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentConditionalInactivity": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Value must be one of `IS`.\n"
                 },
                 "incidentInactivityDuration": {
                     "type": "string",
@@ -2612,15 +2625,15 @@
                 },
                 "incidentPostMortemCondition": {
                     "type": "string",
-                    "description": "Value must be one off `ALL`, `ANY`, `NONE`.\n"
+                    "description": "Value must be one of `ALL`, `ANY`, `NONE`.\n"
                 },
                 "incidentPostMortemConditionCause": {
                     "type": "string",
-                    "description": "[DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "[DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentPostMortemConditionStatus": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "incidentPostMortemStatuses": {
                     "type": "array",
@@ -2644,7 +2657,7 @@
                 },
                 "triggerType": {
                     "type": "string",
-                    "description": "Value must be one off \u003cspan pulumi-lang-nodejs=\"`postMortem`\" pulumi-lang-dotnet=\"`PostMortem`\" pulumi-lang-go=\"`postMortem`\" pulumi-lang-python=\"`post_mortem`\" pulumi-lang-yaml=\"`postMortem`\" pulumi-lang-java=\"`postMortem`\"\u003e`postMortem`\u003c/span\u003e.\n"
+                    "description": "Value must be one of \u003cspan pulumi-lang-nodejs=\"`postMortem`\" pulumi-lang-dotnet=\"`PostMortem`\" pulumi-lang-go=\"`postMortem`\" pulumi-lang-python=\"`post_mortem`\" pulumi-lang-yaml=\"`postMortem`\" pulumi-lang-java=\"`postMortem`\"\u003e`postMortem`\u003c/span\u003e.\n"
                 },
                 "triggers": {
                     "type": "array",
@@ -2679,11 +2692,11 @@
             "properties": {
                 "pulseCondition": {
                     "type": "string",
-                    "description": "Value must be one off `ALL`, `ANY`, `NONE`.\n"
+                    "description": "Value must be one of `ALL`, `ANY`, `NONE`.\n"
                 },
                 "pulseConditionLabel": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "pulseConditionLabelUseRegexp": {
                     "type": "boolean",
@@ -2691,7 +2704,7 @@
                 },
                 "pulseConditionPayload": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "pulseConditionPayloadUseRegexp": {
                     "type": "boolean",
@@ -2699,7 +2712,7 @@
                 },
                 "pulseConditionSource": {
                     "type": "string",
-                    "description": "Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
+                    "description": "Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.\n"
                 },
                 "pulseConditionSourceUseRegexp": {
                     "type": "boolean",
@@ -2729,7 +2742,7 @@
                 },
                 "triggerType": {
                     "type": "string",
-                    "description": "Value must be one off \u003cspan pulumi-lang-nodejs=\"`pulse`\" pulumi-lang-dotnet=\"`Pulse`\" pulumi-lang-go=\"`pulse`\" pulumi-lang-python=\"`pulse`\" pulumi-lang-yaml=\"`pulse`\" pulumi-lang-java=\"`pulse`\"\u003e`pulse`\u003c/span\u003e.\n"
+                    "description": "Value must be one of \u003cspan pulumi-lang-nodejs=\"`pulse`\" pulumi-lang-dotnet=\"`Pulse`\" pulumi-lang-go=\"`pulse`\" pulumi-lang-python=\"`pulse`\" pulumi-lang-yaml=\"`pulse`\" pulumi-lang-java=\"`pulse`\"\u003e`pulse`\u003c/span\u003e.\n"
                 },
                 "triggers": {
                     "type": "array",
@@ -2759,7 +2772,7 @@
             "properties": {
                 "triggerType": {
                     "type": "string",
-                    "description": "Value must be one off \u003cspan pulumi-lang-nodejs=\"`simple`\" pulumi-lang-dotnet=\"`Simple`\" pulumi-lang-go=\"`simple`\" pulumi-lang-python=\"`simple`\" pulumi-lang-yaml=\"`simple`\" pulumi-lang-java=\"`simple`\"\u003e`simple`\u003c/span\u003e.\n"
+                    "description": "Value must be one of \u003cspan pulumi-lang-nodejs=\"`simple`\" pulumi-lang-dotnet=\"`Simple`\" pulumi-lang-go=\"`simple`\" pulumi-lang-python=\"`simple`\" pulumi-lang-yaml=\"`simple`\" pulumi-lang-java=\"`simple`\"\u003e`simple`\u003c/span\u003e.\n"
                 },
                 "triggers": {
                     "type": "array",
@@ -9536,20 +9549,134 @@
         },
         "rootly:index/getServicesService:getServicesService": {
             "properties": {
+                "alertBroadcastChannel": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "alertBroadcastEnabled": {
+                    "type": "boolean"
+                },
+                "alertUrgencyId": {
+                    "type": "string"
+                },
+                "alertsEmailAddress": {
+                    "type": "string"
+                },
+                "alertsEmailEnabled": {
+                    "type": "boolean"
+                },
+                "backstageId": {
+                    "type": "string"
+                },
                 "color": {
+                    "type": "string"
+                },
+                "cortexId": {
                     "type": "string"
                 },
                 "description": {
                     "type": "string"
                 },
+                "environmentIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "escalationPolicyId": {
+                    "type": "string"
+                },
+                "externalId": {
+                    "type": "string"
+                },
+                "githubRepositoryBranch": {
+                    "type": "string"
+                },
+                "githubRepositoryName": {
+                    "type": "string"
+                },
+                "gitlabRepositoryBranch": {
+                    "type": "string"
+                },
+                "gitlabRepositoryName": {
+                    "type": "string"
+                },
                 "id": {
+                    "type": "string"
+                },
+                "incidentBroadcastChannel": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "incidentBroadcastEnabled": {
+                    "type": "boolean"
+                },
+                "kubernetesDeploymentName": {
                     "type": "string"
                 },
                 "name": {
                     "type": "string"
                 },
+                "notifyEmails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "opsgenieId": {
+                    "type": "string"
+                },
+                "ownerGroupIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ownerUserIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "pagerdutyId": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "integer"
+                },
+                "properties": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "publicDescription": {
                     "type": "string"
+                },
+                "serviceIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "serviceNowCiSysId": {
+                    "type": "string"
+                },
+                "slackAliases": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "slackChannels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "slug": {
                     "type": "string"
@@ -9557,11 +9684,39 @@
             },
             "type": "object",
             "required": [
+                "alertBroadcastChannel",
+                "alertBroadcastEnabled",
+                "alertUrgencyId",
+                "alertsEmailAddress",
+                "alertsEmailEnabled",
+                "backstageId",
                 "color",
+                "cortexId",
                 "description",
+                "environmentIds",
+                "escalationPolicyId",
+                "externalId",
+                "githubRepositoryBranch",
+                "githubRepositoryName",
+                "gitlabRepositoryBranch",
+                "gitlabRepositoryName",
                 "id",
+                "incidentBroadcastChannel",
+                "incidentBroadcastEnabled",
+                "kubernetesDeploymentName",
                 "name",
+                "notifyEmails",
+                "opsgenieId",
+                "ownerGroupIds",
+                "ownerUserIds",
+                "pagerdutyId",
+                "position",
+                "properties",
                 "publicDescription",
+                "serviceIds",
+                "serviceNowCiSysId",
+                "slackAliases",
+                "slackChannels",
                 "slug"
             ],
             "language": {
@@ -9669,7 +9824,7 @@
     },
     "resources": {
         "rootly:index/alertField:AlertField": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.AlertField \" pulumi-lang-dotnet=\"\nrootly.AlertField \" pulumi-lang-go=\"\nAlertField \" pulumi-lang-python=\"\nAlertField \" pulumi-lang-yaml=\"\nrootly.AlertField \" pulumi-lang-java=\"\nrootly.AlertField \"\u003e\nrootly.AlertField \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/alertField:AlertField primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_alert_field\" \"cloud_region\" {\n  label = \"Cloud Region\"\n  kind  = \"select\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.AlertField \" pulumi-lang-dotnet=\"\nrootly.AlertField \" pulumi-lang-go=\"\nAlertField \" pulumi-lang-python=\"\nAlertField \" pulumi-lang-yaml=\"\nrootly.AlertField \" pulumi-lang-java=\"\nrootly.AlertField \"\u003e\nrootly.AlertField \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/alertField:AlertField primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "kind": {
                     "type": "string",
@@ -10003,7 +10158,7 @@
             }
         },
         "rootly:index/alertRoutingRule:AlertRoutingRule": {
-            "description": "*Note: If you are an advanced alert routing user, you should use the Alert Routes resource/data source instead of this one. If you don't know whether you are an advanced alert routing user, please contact Rootly customer support.*\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.AlertRoutingRule \" pulumi-lang-dotnet=\"\nrootly.AlertRoutingRule \" pulumi-lang-go=\"\nAlertRoutingRule \" pulumi-lang-python=\"\nAlertRoutingRule \" pulumi-lang-yaml=\"\nrootly.AlertRoutingRule \" pulumi-lang-java=\"\nrootly.AlertRoutingRule \"\u003e\nrootly.AlertRoutingRule \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/alertRoutingRule:AlertRoutingRule primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "*Note: If you are an advanced alert routing user, you should use the Alert Routes resource/data source instead of this one. If you don't know whether you are an advanced alert routing user, please contact Rootly customer support.*\n\n## Example Usage\n\n```shell\nresource \"rootly_alert_routing_rule\" \"production_alerts\" {\n  name = \"Route production alerts\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.AlertRoutingRule \" pulumi-lang-dotnet=\"\nrootly.AlertRoutingRule \" pulumi-lang-go=\"\nAlertRoutingRule \" pulumi-lang-python=\"\nAlertRoutingRule \" pulumi-lang-yaml=\"\nrootly.AlertRoutingRule \" pulumi-lang-java=\"\nrootly.AlertRoutingRule \"\u003e\nrootly.AlertRoutingRule \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/alertRoutingRule:AlertRoutingRule primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "alertsSourceId": {
                     "type": "string",
@@ -10137,7 +10292,7 @@
             }
         },
         "rootly:index/alertUrgency:AlertUrgency": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.AlertUrgency \" pulumi-lang-dotnet=\"\nrootly.AlertUrgency \" pulumi-lang-go=\"\nAlertUrgency \" pulumi-lang-python=\"\nAlertUrgency \" pulumi-lang-yaml=\"\nrootly.AlertUrgency \" pulumi-lang-java=\"\nrootly.AlertUrgency \"\u003e\nrootly.AlertUrgency \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/alertUrgency:AlertUrgency primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_alert_urgency\" \"critical\" {\n  name        = \"Critical\"\n  description = \"Requires immediate attention — pages on-call\"\n}\n\nresource \"rootly_alert_urgency\" \"warning\" {\n  name        = \"Warning\"\n  description = \"Should be investigated within 30 minutes\"\n}\n\nresource \"rootly_alert_urgency\" \"informational\" {\n  name        = \"Informational\"\n  description = \"No immediate action required\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.AlertUrgency \" pulumi-lang-dotnet=\"\nrootly.AlertUrgency \" pulumi-lang-go=\"\nAlertUrgency \" pulumi-lang-python=\"\nAlertUrgency \" pulumi-lang-yaml=\"\nrootly.AlertUrgency \" pulumi-lang-java=\"\nrootly.AlertUrgency \"\u003e\nrootly.AlertUrgency \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/alertUrgency:AlertUrgency primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "description": {
                     "type": "string",
@@ -10260,7 +10415,7 @@
                 },
                 "sourceType": {
                     "type": "string",
-                    "description": "The alert source type. Value must be one of \u003cspan pulumi-lang-nodejs=\"`email`\" pulumi-lang-dotnet=\"`Email`\" pulumi-lang-go=\"`email`\" pulumi-lang-python=\"`email`\" pulumi-lang-yaml=\"`email`\" pulumi-lang-java=\"`email`\"\u003e`email`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appDynamics`\" pulumi-lang-dotnet=\"`AppDynamics`\" pulumi-lang-go=\"`appDynamics`\" pulumi-lang-python=\"`app_dynamics`\" pulumi-lang-yaml=\"`appDynamics`\" pulumi-lang-java=\"`appDynamics`\"\u003e`appDynamics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`catchpoint`\" pulumi-lang-dotnet=\"`Catchpoint`\" pulumi-lang-go=\"`catchpoint`\" pulumi-lang-python=\"`catchpoint`\" pulumi-lang-yaml=\"`catchpoint`\" pulumi-lang-java=\"`catchpoint`\"\u003e`catchpoint`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`datadog`\" pulumi-lang-dotnet=\"`Datadog`\" pulumi-lang-go=\"`datadog`\" pulumi-lang-python=\"`datadog`\" pulumi-lang-yaml=\"`datadog`\" pulumi-lang-java=\"`datadog`\"\u003e`datadog`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`alertmanager`\" pulumi-lang-dotnet=\"`Alertmanager`\" pulumi-lang-go=\"`alertmanager`\" pulumi-lang-python=\"`alertmanager`\" pulumi-lang-yaml=\"`alertmanager`\" pulumi-lang-java=\"`alertmanager`\"\u003e`alertmanager`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`googleCloud`\" pulumi-lang-dotnet=\"`GoogleCloud`\" pulumi-lang-go=\"`googleCloud`\" pulumi-lang-python=\"`google_cloud`\" pulumi-lang-yaml=\"`googleCloud`\" pulumi-lang-java=\"`googleCloud`\"\u003e`googleCloud`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`grafana`\" pulumi-lang-dotnet=\"`Grafana`\" pulumi-lang-go=\"`grafana`\" pulumi-lang-python=\"`grafana`\" pulumi-lang-yaml=\"`grafana`\" pulumi-lang-java=\"`grafana`\"\u003e`grafana`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`sentry`\" pulumi-lang-dotnet=\"`Sentry`\" pulumi-lang-go=\"`sentry`\" pulumi-lang-python=\"`sentry`\" pulumi-lang-yaml=\"`sentry`\" pulumi-lang-java=\"`sentry`\"\u003e`sentry`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`genericWebhook`\" pulumi-lang-dotnet=\"`GenericWebhook`\" pulumi-lang-go=\"`genericWebhook`\" pulumi-lang-python=\"`generic_webhook`\" pulumi-lang-yaml=\"`genericWebhook`\" pulumi-lang-java=\"`genericWebhook`\"\u003e`genericWebhook`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`cloudWatch`\" pulumi-lang-dotnet=\"`CloudWatch`\" pulumi-lang-go=\"`cloudWatch`\" pulumi-lang-python=\"`cloud_watch`\" pulumi-lang-yaml=\"`cloudWatch`\" pulumi-lang-java=\"`cloudWatch`\"\u003e`cloudWatch`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`checkly`\" pulumi-lang-dotnet=\"`Checkly`\" pulumi-lang-go=\"`checkly`\" pulumi-lang-python=\"`checkly`\" pulumi-lang-yaml=\"`checkly`\" pulumi-lang-java=\"`checkly`\"\u003e`checkly`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`azure`\" pulumi-lang-dotnet=\"`Azure`\" pulumi-lang-go=\"`azure`\" pulumi-lang-python=\"`azure`\" pulumi-lang-yaml=\"`azure`\" pulumi-lang-java=\"`azure`\"\u003e`azure`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`newRelic`\" pulumi-lang-dotnet=\"`NewRelic`\" pulumi-lang-go=\"`newRelic`\" pulumi-lang-python=\"`new_relic`\" pulumi-lang-yaml=\"`newRelic`\" pulumi-lang-java=\"`newRelic`\"\u003e`newRelic`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`splunk`\" pulumi-lang-dotnet=\"`Splunk`\" pulumi-lang-go=\"`splunk`\" pulumi-lang-python=\"`splunk`\" pulumi-lang-yaml=\"`splunk`\" pulumi-lang-java=\"`splunk`\"\u003e`splunk`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`chronosphere`\" pulumi-lang-dotnet=\"`Chronosphere`\" pulumi-lang-go=\"`chronosphere`\" pulumi-lang-python=\"`chronosphere`\" pulumi-lang-yaml=\"`chronosphere`\" pulumi-lang-java=\"`chronosphere`\"\u003e`chronosphere`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appOptics`\" pulumi-lang-dotnet=\"`AppOptics`\" pulumi-lang-go=\"`appOptics`\" pulumi-lang-python=\"`app_optics`\" pulumi-lang-yaml=\"`appOptics`\" pulumi-lang-java=\"`appOptics`\"\u003e`appOptics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`bugSnag`\" pulumi-lang-dotnet=\"`BugSnag`\" pulumi-lang-go=\"`bugSnag`\" pulumi-lang-python=\"`bug_snag`\" pulumi-lang-yaml=\"`bugSnag`\" pulumi-lang-java=\"`bugSnag`\"\u003e`bugSnag`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`honeycomb`\" pulumi-lang-dotnet=\"`Honeycomb`\" pulumi-lang-go=\"`honeycomb`\" pulumi-lang-python=\"`honeycomb`\" pulumi-lang-yaml=\"`honeycomb`\" pulumi-lang-java=\"`honeycomb`\"\u003e`honeycomb`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`monteCarlo`\" pulumi-lang-dotnet=\"`MonteCarlo`\" pulumi-lang-go=\"`monteCarlo`\" pulumi-lang-python=\"`monte_carlo`\" pulumi-lang-yaml=\"`monteCarlo`\" pulumi-lang-java=\"`monteCarlo`\"\u003e`monteCarlo`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`nagios`\" pulumi-lang-dotnet=\"`Nagios`\" pulumi-lang-go=\"`nagios`\" pulumi-lang-python=\"`nagios`\" pulumi-lang-yaml=\"`nagios`\" pulumi-lang-java=\"`nagios`\"\u003e`nagios`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`prtg`\" pulumi-lang-dotnet=\"`Prtg`\" pulumi-lang-go=\"`prtg`\" pulumi-lang-python=\"`prtg`\" pulumi-lang-yaml=\"`prtg`\" pulumi-lang-java=\"`prtg`\"\u003e`prtg`\u003c/span\u003e.\n"
+                    "description": "The alert source type. Value must be one of \u003cspan pulumi-lang-nodejs=\"`email`\" pulumi-lang-dotnet=\"`Email`\" pulumi-lang-go=\"`email`\" pulumi-lang-python=\"`email`\" pulumi-lang-yaml=\"`email`\" pulumi-lang-java=\"`email`\"\u003e`email`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appDynamics`\" pulumi-lang-dotnet=\"`AppDynamics`\" pulumi-lang-go=\"`appDynamics`\" pulumi-lang-python=\"`app_dynamics`\" pulumi-lang-yaml=\"`appDynamics`\" pulumi-lang-java=\"`appDynamics`\"\u003e`appDynamics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`catchpoint`\" pulumi-lang-dotnet=\"`Catchpoint`\" pulumi-lang-go=\"`catchpoint`\" pulumi-lang-python=\"`catchpoint`\" pulumi-lang-yaml=\"`catchpoint`\" pulumi-lang-java=\"`catchpoint`\"\u003e`catchpoint`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`datadog`\" pulumi-lang-dotnet=\"`Datadog`\" pulumi-lang-go=\"`datadog`\" pulumi-lang-python=\"`datadog`\" pulumi-lang-yaml=\"`datadog`\" pulumi-lang-java=\"`datadog`\"\u003e`datadog`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`dynatrace`\" pulumi-lang-dotnet=\"`Dynatrace`\" pulumi-lang-go=\"`dynatrace`\" pulumi-lang-python=\"`dynatrace`\" pulumi-lang-yaml=\"`dynatrace`\" pulumi-lang-java=\"`dynatrace`\"\u003e`dynatrace`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`alertmanager`\" pulumi-lang-dotnet=\"`Alertmanager`\" pulumi-lang-go=\"`alertmanager`\" pulumi-lang-python=\"`alertmanager`\" pulumi-lang-yaml=\"`alertmanager`\" pulumi-lang-java=\"`alertmanager`\"\u003e`alertmanager`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`googleCloud`\" pulumi-lang-dotnet=\"`GoogleCloud`\" pulumi-lang-go=\"`googleCloud`\" pulumi-lang-python=\"`google_cloud`\" pulumi-lang-yaml=\"`googleCloud`\" pulumi-lang-java=\"`googleCloud`\"\u003e`googleCloud`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`grafana`\" pulumi-lang-dotnet=\"`Grafana`\" pulumi-lang-go=\"`grafana`\" pulumi-lang-python=\"`grafana`\" pulumi-lang-yaml=\"`grafana`\" pulumi-lang-java=\"`grafana`\"\u003e`grafana`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`sentry`\" pulumi-lang-dotnet=\"`Sentry`\" pulumi-lang-go=\"`sentry`\" pulumi-lang-python=\"`sentry`\" pulumi-lang-yaml=\"`sentry`\" pulumi-lang-java=\"`sentry`\"\u003e`sentry`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`genericWebhook`\" pulumi-lang-dotnet=\"`GenericWebhook`\" pulumi-lang-go=\"`genericWebhook`\" pulumi-lang-python=\"`generic_webhook`\" pulumi-lang-yaml=\"`genericWebhook`\" pulumi-lang-java=\"`genericWebhook`\"\u003e`genericWebhook`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`cloudWatch`\" pulumi-lang-dotnet=\"`CloudWatch`\" pulumi-lang-go=\"`cloudWatch`\" pulumi-lang-python=\"`cloud_watch`\" pulumi-lang-yaml=\"`cloudWatch`\" pulumi-lang-java=\"`cloudWatch`\"\u003e`cloudWatch`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`awsSns`\" pulumi-lang-dotnet=\"`AwsSns`\" pulumi-lang-go=\"`awsSns`\" pulumi-lang-python=\"`aws_sns`\" pulumi-lang-yaml=\"`awsSns`\" pulumi-lang-java=\"`awsSns`\"\u003e`awsSns`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`checkly`\" pulumi-lang-dotnet=\"`Checkly`\" pulumi-lang-go=\"`checkly`\" pulumi-lang-python=\"`checkly`\" pulumi-lang-yaml=\"`checkly`\" pulumi-lang-java=\"`checkly`\"\u003e`checkly`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`azure`\" pulumi-lang-dotnet=\"`Azure`\" pulumi-lang-go=\"`azure`\" pulumi-lang-python=\"`azure`\" pulumi-lang-yaml=\"`azure`\" pulumi-lang-java=\"`azure`\"\u003e`azure`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`newRelic`\" pulumi-lang-dotnet=\"`NewRelic`\" pulumi-lang-go=\"`newRelic`\" pulumi-lang-python=\"`new_relic`\" pulumi-lang-yaml=\"`newRelic`\" pulumi-lang-java=\"`newRelic`\"\u003e`newRelic`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`splunk`\" pulumi-lang-dotnet=\"`Splunk`\" pulumi-lang-go=\"`splunk`\" pulumi-lang-python=\"`splunk`\" pulumi-lang-yaml=\"`splunk`\" pulumi-lang-java=\"`splunk`\"\u003e`splunk`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`chronosphere`\" pulumi-lang-dotnet=\"`Chronosphere`\" pulumi-lang-go=\"`chronosphere`\" pulumi-lang-python=\"`chronosphere`\" pulumi-lang-yaml=\"`chronosphere`\" pulumi-lang-java=\"`chronosphere`\"\u003e`chronosphere`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appOptics`\" pulumi-lang-dotnet=\"`AppOptics`\" pulumi-lang-go=\"`appOptics`\" pulumi-lang-python=\"`app_optics`\" pulumi-lang-yaml=\"`appOptics`\" pulumi-lang-java=\"`appOptics`\"\u003e`appOptics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`bugSnag`\" pulumi-lang-dotnet=\"`BugSnag`\" pulumi-lang-go=\"`bugSnag`\" pulumi-lang-python=\"`bug_snag`\" pulumi-lang-yaml=\"`bugSnag`\" pulumi-lang-java=\"`bugSnag`\"\u003e`bugSnag`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`honeycomb`\" pulumi-lang-dotnet=\"`Honeycomb`\" pulumi-lang-go=\"`honeycomb`\" pulumi-lang-python=\"`honeycomb`\" pulumi-lang-yaml=\"`honeycomb`\" pulumi-lang-java=\"`honeycomb`\"\u003e`honeycomb`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`monteCarlo`\" pulumi-lang-dotnet=\"`MonteCarlo`\" pulumi-lang-go=\"`monteCarlo`\" pulumi-lang-python=\"`monte_carlo`\" pulumi-lang-yaml=\"`monteCarlo`\" pulumi-lang-java=\"`monteCarlo`\"\u003e`monteCarlo`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`nagios`\" pulumi-lang-dotnet=\"`Nagios`\" pulumi-lang-go=\"`nagios`\" pulumi-lang-python=\"`nagios`\" pulumi-lang-yaml=\"`nagios`\" pulumi-lang-java=\"`nagios`\"\u003e`nagios`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`prtg`\" pulumi-lang-dotnet=\"`Prtg`\" pulumi-lang-go=\"`prtg`\" pulumi-lang-python=\"`prtg`\" pulumi-lang-yaml=\"`prtg`\" pulumi-lang-java=\"`prtg`\"\u003e`prtg`\u003c/span\u003e.\n"
                 },
                 "sourceableAttributes": {
                     "$ref": "#/types/rootly:index/AlertsSourceSourceableAttributes:AlertsSourceSourceableAttributes",
@@ -10356,7 +10511,7 @@
                 },
                 "sourceType": {
                     "type": "string",
-                    "description": "The alert source type. Value must be one of \u003cspan pulumi-lang-nodejs=\"`email`\" pulumi-lang-dotnet=\"`Email`\" pulumi-lang-go=\"`email`\" pulumi-lang-python=\"`email`\" pulumi-lang-yaml=\"`email`\" pulumi-lang-java=\"`email`\"\u003e`email`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appDynamics`\" pulumi-lang-dotnet=\"`AppDynamics`\" pulumi-lang-go=\"`appDynamics`\" pulumi-lang-python=\"`app_dynamics`\" pulumi-lang-yaml=\"`appDynamics`\" pulumi-lang-java=\"`appDynamics`\"\u003e`appDynamics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`catchpoint`\" pulumi-lang-dotnet=\"`Catchpoint`\" pulumi-lang-go=\"`catchpoint`\" pulumi-lang-python=\"`catchpoint`\" pulumi-lang-yaml=\"`catchpoint`\" pulumi-lang-java=\"`catchpoint`\"\u003e`catchpoint`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`datadog`\" pulumi-lang-dotnet=\"`Datadog`\" pulumi-lang-go=\"`datadog`\" pulumi-lang-python=\"`datadog`\" pulumi-lang-yaml=\"`datadog`\" pulumi-lang-java=\"`datadog`\"\u003e`datadog`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`alertmanager`\" pulumi-lang-dotnet=\"`Alertmanager`\" pulumi-lang-go=\"`alertmanager`\" pulumi-lang-python=\"`alertmanager`\" pulumi-lang-yaml=\"`alertmanager`\" pulumi-lang-java=\"`alertmanager`\"\u003e`alertmanager`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`googleCloud`\" pulumi-lang-dotnet=\"`GoogleCloud`\" pulumi-lang-go=\"`googleCloud`\" pulumi-lang-python=\"`google_cloud`\" pulumi-lang-yaml=\"`googleCloud`\" pulumi-lang-java=\"`googleCloud`\"\u003e`googleCloud`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`grafana`\" pulumi-lang-dotnet=\"`Grafana`\" pulumi-lang-go=\"`grafana`\" pulumi-lang-python=\"`grafana`\" pulumi-lang-yaml=\"`grafana`\" pulumi-lang-java=\"`grafana`\"\u003e`grafana`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`sentry`\" pulumi-lang-dotnet=\"`Sentry`\" pulumi-lang-go=\"`sentry`\" pulumi-lang-python=\"`sentry`\" pulumi-lang-yaml=\"`sentry`\" pulumi-lang-java=\"`sentry`\"\u003e`sentry`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`genericWebhook`\" pulumi-lang-dotnet=\"`GenericWebhook`\" pulumi-lang-go=\"`genericWebhook`\" pulumi-lang-python=\"`generic_webhook`\" pulumi-lang-yaml=\"`genericWebhook`\" pulumi-lang-java=\"`genericWebhook`\"\u003e`genericWebhook`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`cloudWatch`\" pulumi-lang-dotnet=\"`CloudWatch`\" pulumi-lang-go=\"`cloudWatch`\" pulumi-lang-python=\"`cloud_watch`\" pulumi-lang-yaml=\"`cloudWatch`\" pulumi-lang-java=\"`cloudWatch`\"\u003e`cloudWatch`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`checkly`\" pulumi-lang-dotnet=\"`Checkly`\" pulumi-lang-go=\"`checkly`\" pulumi-lang-python=\"`checkly`\" pulumi-lang-yaml=\"`checkly`\" pulumi-lang-java=\"`checkly`\"\u003e`checkly`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`azure`\" pulumi-lang-dotnet=\"`Azure`\" pulumi-lang-go=\"`azure`\" pulumi-lang-python=\"`azure`\" pulumi-lang-yaml=\"`azure`\" pulumi-lang-java=\"`azure`\"\u003e`azure`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`newRelic`\" pulumi-lang-dotnet=\"`NewRelic`\" pulumi-lang-go=\"`newRelic`\" pulumi-lang-python=\"`new_relic`\" pulumi-lang-yaml=\"`newRelic`\" pulumi-lang-java=\"`newRelic`\"\u003e`newRelic`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`splunk`\" pulumi-lang-dotnet=\"`Splunk`\" pulumi-lang-go=\"`splunk`\" pulumi-lang-python=\"`splunk`\" pulumi-lang-yaml=\"`splunk`\" pulumi-lang-java=\"`splunk`\"\u003e`splunk`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`chronosphere`\" pulumi-lang-dotnet=\"`Chronosphere`\" pulumi-lang-go=\"`chronosphere`\" pulumi-lang-python=\"`chronosphere`\" pulumi-lang-yaml=\"`chronosphere`\" pulumi-lang-java=\"`chronosphere`\"\u003e`chronosphere`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appOptics`\" pulumi-lang-dotnet=\"`AppOptics`\" pulumi-lang-go=\"`appOptics`\" pulumi-lang-python=\"`app_optics`\" pulumi-lang-yaml=\"`appOptics`\" pulumi-lang-java=\"`appOptics`\"\u003e`appOptics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`bugSnag`\" pulumi-lang-dotnet=\"`BugSnag`\" pulumi-lang-go=\"`bugSnag`\" pulumi-lang-python=\"`bug_snag`\" pulumi-lang-yaml=\"`bugSnag`\" pulumi-lang-java=\"`bugSnag`\"\u003e`bugSnag`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`honeycomb`\" pulumi-lang-dotnet=\"`Honeycomb`\" pulumi-lang-go=\"`honeycomb`\" pulumi-lang-python=\"`honeycomb`\" pulumi-lang-yaml=\"`honeycomb`\" pulumi-lang-java=\"`honeycomb`\"\u003e`honeycomb`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`monteCarlo`\" pulumi-lang-dotnet=\"`MonteCarlo`\" pulumi-lang-go=\"`monteCarlo`\" pulumi-lang-python=\"`monte_carlo`\" pulumi-lang-yaml=\"`monteCarlo`\" pulumi-lang-java=\"`monteCarlo`\"\u003e`monteCarlo`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`nagios`\" pulumi-lang-dotnet=\"`Nagios`\" pulumi-lang-go=\"`nagios`\" pulumi-lang-python=\"`nagios`\" pulumi-lang-yaml=\"`nagios`\" pulumi-lang-java=\"`nagios`\"\u003e`nagios`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`prtg`\" pulumi-lang-dotnet=\"`Prtg`\" pulumi-lang-go=\"`prtg`\" pulumi-lang-python=\"`prtg`\" pulumi-lang-yaml=\"`prtg`\" pulumi-lang-java=\"`prtg`\"\u003e`prtg`\u003c/span\u003e.\n",
+                    "description": "The alert source type. Value must be one of \u003cspan pulumi-lang-nodejs=\"`email`\" pulumi-lang-dotnet=\"`Email`\" pulumi-lang-go=\"`email`\" pulumi-lang-python=\"`email`\" pulumi-lang-yaml=\"`email`\" pulumi-lang-java=\"`email`\"\u003e`email`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appDynamics`\" pulumi-lang-dotnet=\"`AppDynamics`\" pulumi-lang-go=\"`appDynamics`\" pulumi-lang-python=\"`app_dynamics`\" pulumi-lang-yaml=\"`appDynamics`\" pulumi-lang-java=\"`appDynamics`\"\u003e`appDynamics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`catchpoint`\" pulumi-lang-dotnet=\"`Catchpoint`\" pulumi-lang-go=\"`catchpoint`\" pulumi-lang-python=\"`catchpoint`\" pulumi-lang-yaml=\"`catchpoint`\" pulumi-lang-java=\"`catchpoint`\"\u003e`catchpoint`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`datadog`\" pulumi-lang-dotnet=\"`Datadog`\" pulumi-lang-go=\"`datadog`\" pulumi-lang-python=\"`datadog`\" pulumi-lang-yaml=\"`datadog`\" pulumi-lang-java=\"`datadog`\"\u003e`datadog`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`dynatrace`\" pulumi-lang-dotnet=\"`Dynatrace`\" pulumi-lang-go=\"`dynatrace`\" pulumi-lang-python=\"`dynatrace`\" pulumi-lang-yaml=\"`dynatrace`\" pulumi-lang-java=\"`dynatrace`\"\u003e`dynatrace`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`alertmanager`\" pulumi-lang-dotnet=\"`Alertmanager`\" pulumi-lang-go=\"`alertmanager`\" pulumi-lang-python=\"`alertmanager`\" pulumi-lang-yaml=\"`alertmanager`\" pulumi-lang-java=\"`alertmanager`\"\u003e`alertmanager`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`googleCloud`\" pulumi-lang-dotnet=\"`GoogleCloud`\" pulumi-lang-go=\"`googleCloud`\" pulumi-lang-python=\"`google_cloud`\" pulumi-lang-yaml=\"`googleCloud`\" pulumi-lang-java=\"`googleCloud`\"\u003e`googleCloud`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`grafana`\" pulumi-lang-dotnet=\"`Grafana`\" pulumi-lang-go=\"`grafana`\" pulumi-lang-python=\"`grafana`\" pulumi-lang-yaml=\"`grafana`\" pulumi-lang-java=\"`grafana`\"\u003e`grafana`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`sentry`\" pulumi-lang-dotnet=\"`Sentry`\" pulumi-lang-go=\"`sentry`\" pulumi-lang-python=\"`sentry`\" pulumi-lang-yaml=\"`sentry`\" pulumi-lang-java=\"`sentry`\"\u003e`sentry`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`genericWebhook`\" pulumi-lang-dotnet=\"`GenericWebhook`\" pulumi-lang-go=\"`genericWebhook`\" pulumi-lang-python=\"`generic_webhook`\" pulumi-lang-yaml=\"`genericWebhook`\" pulumi-lang-java=\"`genericWebhook`\"\u003e`genericWebhook`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`cloudWatch`\" pulumi-lang-dotnet=\"`CloudWatch`\" pulumi-lang-go=\"`cloudWatch`\" pulumi-lang-python=\"`cloud_watch`\" pulumi-lang-yaml=\"`cloudWatch`\" pulumi-lang-java=\"`cloudWatch`\"\u003e`cloudWatch`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`awsSns`\" pulumi-lang-dotnet=\"`AwsSns`\" pulumi-lang-go=\"`awsSns`\" pulumi-lang-python=\"`aws_sns`\" pulumi-lang-yaml=\"`awsSns`\" pulumi-lang-java=\"`awsSns`\"\u003e`awsSns`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`checkly`\" pulumi-lang-dotnet=\"`Checkly`\" pulumi-lang-go=\"`checkly`\" pulumi-lang-python=\"`checkly`\" pulumi-lang-yaml=\"`checkly`\" pulumi-lang-java=\"`checkly`\"\u003e`checkly`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`azure`\" pulumi-lang-dotnet=\"`Azure`\" pulumi-lang-go=\"`azure`\" pulumi-lang-python=\"`azure`\" pulumi-lang-yaml=\"`azure`\" pulumi-lang-java=\"`azure`\"\u003e`azure`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`newRelic`\" pulumi-lang-dotnet=\"`NewRelic`\" pulumi-lang-go=\"`newRelic`\" pulumi-lang-python=\"`new_relic`\" pulumi-lang-yaml=\"`newRelic`\" pulumi-lang-java=\"`newRelic`\"\u003e`newRelic`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`splunk`\" pulumi-lang-dotnet=\"`Splunk`\" pulumi-lang-go=\"`splunk`\" pulumi-lang-python=\"`splunk`\" pulumi-lang-yaml=\"`splunk`\" pulumi-lang-java=\"`splunk`\"\u003e`splunk`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`chronosphere`\" pulumi-lang-dotnet=\"`Chronosphere`\" pulumi-lang-go=\"`chronosphere`\" pulumi-lang-python=\"`chronosphere`\" pulumi-lang-yaml=\"`chronosphere`\" pulumi-lang-java=\"`chronosphere`\"\u003e`chronosphere`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appOptics`\" pulumi-lang-dotnet=\"`AppOptics`\" pulumi-lang-go=\"`appOptics`\" pulumi-lang-python=\"`app_optics`\" pulumi-lang-yaml=\"`appOptics`\" pulumi-lang-java=\"`appOptics`\"\u003e`appOptics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`bugSnag`\" pulumi-lang-dotnet=\"`BugSnag`\" pulumi-lang-go=\"`bugSnag`\" pulumi-lang-python=\"`bug_snag`\" pulumi-lang-yaml=\"`bugSnag`\" pulumi-lang-java=\"`bugSnag`\"\u003e`bugSnag`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`honeycomb`\" pulumi-lang-dotnet=\"`Honeycomb`\" pulumi-lang-go=\"`honeycomb`\" pulumi-lang-python=\"`honeycomb`\" pulumi-lang-yaml=\"`honeycomb`\" pulumi-lang-java=\"`honeycomb`\"\u003e`honeycomb`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`monteCarlo`\" pulumi-lang-dotnet=\"`MonteCarlo`\" pulumi-lang-go=\"`monteCarlo`\" pulumi-lang-python=\"`monte_carlo`\" pulumi-lang-yaml=\"`monteCarlo`\" pulumi-lang-java=\"`monteCarlo`\"\u003e`monteCarlo`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`nagios`\" pulumi-lang-dotnet=\"`Nagios`\" pulumi-lang-go=\"`nagios`\" pulumi-lang-python=\"`nagios`\" pulumi-lang-yaml=\"`nagios`\" pulumi-lang-java=\"`nagios`\"\u003e`nagios`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`prtg`\" pulumi-lang-dotnet=\"`Prtg`\" pulumi-lang-go=\"`prtg`\" pulumi-lang-python=\"`prtg`\" pulumi-lang-yaml=\"`prtg`\" pulumi-lang-java=\"`prtg`\"\u003e`prtg`\u003c/span\u003e.\n",
                     "willReplaceOnChanges": true
                 },
                 "sourceableAttributes": {
@@ -10439,7 +10594,7 @@
                     },
                     "sourceType": {
                         "type": "string",
-                        "description": "The alert source type. Value must be one of \u003cspan pulumi-lang-nodejs=\"`email`\" pulumi-lang-dotnet=\"`Email`\" pulumi-lang-go=\"`email`\" pulumi-lang-python=\"`email`\" pulumi-lang-yaml=\"`email`\" pulumi-lang-java=\"`email`\"\u003e`email`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appDynamics`\" pulumi-lang-dotnet=\"`AppDynamics`\" pulumi-lang-go=\"`appDynamics`\" pulumi-lang-python=\"`app_dynamics`\" pulumi-lang-yaml=\"`appDynamics`\" pulumi-lang-java=\"`appDynamics`\"\u003e`appDynamics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`catchpoint`\" pulumi-lang-dotnet=\"`Catchpoint`\" pulumi-lang-go=\"`catchpoint`\" pulumi-lang-python=\"`catchpoint`\" pulumi-lang-yaml=\"`catchpoint`\" pulumi-lang-java=\"`catchpoint`\"\u003e`catchpoint`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`datadog`\" pulumi-lang-dotnet=\"`Datadog`\" pulumi-lang-go=\"`datadog`\" pulumi-lang-python=\"`datadog`\" pulumi-lang-yaml=\"`datadog`\" pulumi-lang-java=\"`datadog`\"\u003e`datadog`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`alertmanager`\" pulumi-lang-dotnet=\"`Alertmanager`\" pulumi-lang-go=\"`alertmanager`\" pulumi-lang-python=\"`alertmanager`\" pulumi-lang-yaml=\"`alertmanager`\" pulumi-lang-java=\"`alertmanager`\"\u003e`alertmanager`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`googleCloud`\" pulumi-lang-dotnet=\"`GoogleCloud`\" pulumi-lang-go=\"`googleCloud`\" pulumi-lang-python=\"`google_cloud`\" pulumi-lang-yaml=\"`googleCloud`\" pulumi-lang-java=\"`googleCloud`\"\u003e`googleCloud`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`grafana`\" pulumi-lang-dotnet=\"`Grafana`\" pulumi-lang-go=\"`grafana`\" pulumi-lang-python=\"`grafana`\" pulumi-lang-yaml=\"`grafana`\" pulumi-lang-java=\"`grafana`\"\u003e`grafana`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`sentry`\" pulumi-lang-dotnet=\"`Sentry`\" pulumi-lang-go=\"`sentry`\" pulumi-lang-python=\"`sentry`\" pulumi-lang-yaml=\"`sentry`\" pulumi-lang-java=\"`sentry`\"\u003e`sentry`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`genericWebhook`\" pulumi-lang-dotnet=\"`GenericWebhook`\" pulumi-lang-go=\"`genericWebhook`\" pulumi-lang-python=\"`generic_webhook`\" pulumi-lang-yaml=\"`genericWebhook`\" pulumi-lang-java=\"`genericWebhook`\"\u003e`genericWebhook`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`cloudWatch`\" pulumi-lang-dotnet=\"`CloudWatch`\" pulumi-lang-go=\"`cloudWatch`\" pulumi-lang-python=\"`cloud_watch`\" pulumi-lang-yaml=\"`cloudWatch`\" pulumi-lang-java=\"`cloudWatch`\"\u003e`cloudWatch`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`checkly`\" pulumi-lang-dotnet=\"`Checkly`\" pulumi-lang-go=\"`checkly`\" pulumi-lang-python=\"`checkly`\" pulumi-lang-yaml=\"`checkly`\" pulumi-lang-java=\"`checkly`\"\u003e`checkly`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`azure`\" pulumi-lang-dotnet=\"`Azure`\" pulumi-lang-go=\"`azure`\" pulumi-lang-python=\"`azure`\" pulumi-lang-yaml=\"`azure`\" pulumi-lang-java=\"`azure`\"\u003e`azure`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`newRelic`\" pulumi-lang-dotnet=\"`NewRelic`\" pulumi-lang-go=\"`newRelic`\" pulumi-lang-python=\"`new_relic`\" pulumi-lang-yaml=\"`newRelic`\" pulumi-lang-java=\"`newRelic`\"\u003e`newRelic`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`splunk`\" pulumi-lang-dotnet=\"`Splunk`\" pulumi-lang-go=\"`splunk`\" pulumi-lang-python=\"`splunk`\" pulumi-lang-yaml=\"`splunk`\" pulumi-lang-java=\"`splunk`\"\u003e`splunk`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`chronosphere`\" pulumi-lang-dotnet=\"`Chronosphere`\" pulumi-lang-go=\"`chronosphere`\" pulumi-lang-python=\"`chronosphere`\" pulumi-lang-yaml=\"`chronosphere`\" pulumi-lang-java=\"`chronosphere`\"\u003e`chronosphere`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appOptics`\" pulumi-lang-dotnet=\"`AppOptics`\" pulumi-lang-go=\"`appOptics`\" pulumi-lang-python=\"`app_optics`\" pulumi-lang-yaml=\"`appOptics`\" pulumi-lang-java=\"`appOptics`\"\u003e`appOptics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`bugSnag`\" pulumi-lang-dotnet=\"`BugSnag`\" pulumi-lang-go=\"`bugSnag`\" pulumi-lang-python=\"`bug_snag`\" pulumi-lang-yaml=\"`bugSnag`\" pulumi-lang-java=\"`bugSnag`\"\u003e`bugSnag`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`honeycomb`\" pulumi-lang-dotnet=\"`Honeycomb`\" pulumi-lang-go=\"`honeycomb`\" pulumi-lang-python=\"`honeycomb`\" pulumi-lang-yaml=\"`honeycomb`\" pulumi-lang-java=\"`honeycomb`\"\u003e`honeycomb`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`monteCarlo`\" pulumi-lang-dotnet=\"`MonteCarlo`\" pulumi-lang-go=\"`monteCarlo`\" pulumi-lang-python=\"`monte_carlo`\" pulumi-lang-yaml=\"`monteCarlo`\" pulumi-lang-java=\"`monteCarlo`\"\u003e`monteCarlo`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`nagios`\" pulumi-lang-dotnet=\"`Nagios`\" pulumi-lang-go=\"`nagios`\" pulumi-lang-python=\"`nagios`\" pulumi-lang-yaml=\"`nagios`\" pulumi-lang-java=\"`nagios`\"\u003e`nagios`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`prtg`\" pulumi-lang-dotnet=\"`Prtg`\" pulumi-lang-go=\"`prtg`\" pulumi-lang-python=\"`prtg`\" pulumi-lang-yaml=\"`prtg`\" pulumi-lang-java=\"`prtg`\"\u003e`prtg`\u003c/span\u003e.\n",
+                        "description": "The alert source type. Value must be one of \u003cspan pulumi-lang-nodejs=\"`email`\" pulumi-lang-dotnet=\"`Email`\" pulumi-lang-go=\"`email`\" pulumi-lang-python=\"`email`\" pulumi-lang-yaml=\"`email`\" pulumi-lang-java=\"`email`\"\u003e`email`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appDynamics`\" pulumi-lang-dotnet=\"`AppDynamics`\" pulumi-lang-go=\"`appDynamics`\" pulumi-lang-python=\"`app_dynamics`\" pulumi-lang-yaml=\"`appDynamics`\" pulumi-lang-java=\"`appDynamics`\"\u003e`appDynamics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`catchpoint`\" pulumi-lang-dotnet=\"`Catchpoint`\" pulumi-lang-go=\"`catchpoint`\" pulumi-lang-python=\"`catchpoint`\" pulumi-lang-yaml=\"`catchpoint`\" pulumi-lang-java=\"`catchpoint`\"\u003e`catchpoint`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`datadog`\" pulumi-lang-dotnet=\"`Datadog`\" pulumi-lang-go=\"`datadog`\" pulumi-lang-python=\"`datadog`\" pulumi-lang-yaml=\"`datadog`\" pulumi-lang-java=\"`datadog`\"\u003e`datadog`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`dynatrace`\" pulumi-lang-dotnet=\"`Dynatrace`\" pulumi-lang-go=\"`dynatrace`\" pulumi-lang-python=\"`dynatrace`\" pulumi-lang-yaml=\"`dynatrace`\" pulumi-lang-java=\"`dynatrace`\"\u003e`dynatrace`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`alertmanager`\" pulumi-lang-dotnet=\"`Alertmanager`\" pulumi-lang-go=\"`alertmanager`\" pulumi-lang-python=\"`alertmanager`\" pulumi-lang-yaml=\"`alertmanager`\" pulumi-lang-java=\"`alertmanager`\"\u003e`alertmanager`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`googleCloud`\" pulumi-lang-dotnet=\"`GoogleCloud`\" pulumi-lang-go=\"`googleCloud`\" pulumi-lang-python=\"`google_cloud`\" pulumi-lang-yaml=\"`googleCloud`\" pulumi-lang-java=\"`googleCloud`\"\u003e`googleCloud`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`grafana`\" pulumi-lang-dotnet=\"`Grafana`\" pulumi-lang-go=\"`grafana`\" pulumi-lang-python=\"`grafana`\" pulumi-lang-yaml=\"`grafana`\" pulumi-lang-java=\"`grafana`\"\u003e`grafana`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`sentry`\" pulumi-lang-dotnet=\"`Sentry`\" pulumi-lang-go=\"`sentry`\" pulumi-lang-python=\"`sentry`\" pulumi-lang-yaml=\"`sentry`\" pulumi-lang-java=\"`sentry`\"\u003e`sentry`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`genericWebhook`\" pulumi-lang-dotnet=\"`GenericWebhook`\" pulumi-lang-go=\"`genericWebhook`\" pulumi-lang-python=\"`generic_webhook`\" pulumi-lang-yaml=\"`genericWebhook`\" pulumi-lang-java=\"`genericWebhook`\"\u003e`genericWebhook`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`cloudWatch`\" pulumi-lang-dotnet=\"`CloudWatch`\" pulumi-lang-go=\"`cloudWatch`\" pulumi-lang-python=\"`cloud_watch`\" pulumi-lang-yaml=\"`cloudWatch`\" pulumi-lang-java=\"`cloudWatch`\"\u003e`cloudWatch`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`awsSns`\" pulumi-lang-dotnet=\"`AwsSns`\" pulumi-lang-go=\"`awsSns`\" pulumi-lang-python=\"`aws_sns`\" pulumi-lang-yaml=\"`awsSns`\" pulumi-lang-java=\"`awsSns`\"\u003e`awsSns`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`checkly`\" pulumi-lang-dotnet=\"`Checkly`\" pulumi-lang-go=\"`checkly`\" pulumi-lang-python=\"`checkly`\" pulumi-lang-yaml=\"`checkly`\" pulumi-lang-java=\"`checkly`\"\u003e`checkly`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`azure`\" pulumi-lang-dotnet=\"`Azure`\" pulumi-lang-go=\"`azure`\" pulumi-lang-python=\"`azure`\" pulumi-lang-yaml=\"`azure`\" pulumi-lang-java=\"`azure`\"\u003e`azure`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`newRelic`\" pulumi-lang-dotnet=\"`NewRelic`\" pulumi-lang-go=\"`newRelic`\" pulumi-lang-python=\"`new_relic`\" pulumi-lang-yaml=\"`newRelic`\" pulumi-lang-java=\"`newRelic`\"\u003e`newRelic`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`splunk`\" pulumi-lang-dotnet=\"`Splunk`\" pulumi-lang-go=\"`splunk`\" pulumi-lang-python=\"`splunk`\" pulumi-lang-yaml=\"`splunk`\" pulumi-lang-java=\"`splunk`\"\u003e`splunk`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`chronosphere`\" pulumi-lang-dotnet=\"`Chronosphere`\" pulumi-lang-go=\"`chronosphere`\" pulumi-lang-python=\"`chronosphere`\" pulumi-lang-yaml=\"`chronosphere`\" pulumi-lang-java=\"`chronosphere`\"\u003e`chronosphere`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`appOptics`\" pulumi-lang-dotnet=\"`AppOptics`\" pulumi-lang-go=\"`appOptics`\" pulumi-lang-python=\"`app_optics`\" pulumi-lang-yaml=\"`appOptics`\" pulumi-lang-java=\"`appOptics`\"\u003e`appOptics`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`bugSnag`\" pulumi-lang-dotnet=\"`BugSnag`\" pulumi-lang-go=\"`bugSnag`\" pulumi-lang-python=\"`bug_snag`\" pulumi-lang-yaml=\"`bugSnag`\" pulumi-lang-java=\"`bugSnag`\"\u003e`bugSnag`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`honeycomb`\" pulumi-lang-dotnet=\"`Honeycomb`\" pulumi-lang-go=\"`honeycomb`\" pulumi-lang-python=\"`honeycomb`\" pulumi-lang-yaml=\"`honeycomb`\" pulumi-lang-java=\"`honeycomb`\"\u003e`honeycomb`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`monteCarlo`\" pulumi-lang-dotnet=\"`MonteCarlo`\" pulumi-lang-go=\"`monteCarlo`\" pulumi-lang-python=\"`monte_carlo`\" pulumi-lang-yaml=\"`monteCarlo`\" pulumi-lang-java=\"`monteCarlo`\"\u003e`monteCarlo`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`nagios`\" pulumi-lang-dotnet=\"`Nagios`\" pulumi-lang-go=\"`nagios`\" pulumi-lang-python=\"`nagios`\" pulumi-lang-yaml=\"`nagios`\" pulumi-lang-java=\"`nagios`\"\u003e`nagios`\u003c/span\u003e, \u003cspan pulumi-lang-nodejs=\"`prtg`\" pulumi-lang-dotnet=\"`Prtg`\" pulumi-lang-go=\"`prtg`\" pulumi-lang-python=\"`prtg`\" pulumi-lang-yaml=\"`prtg`\" pulumi-lang-java=\"`prtg`\"\u003e`prtg`\u003c/span\u003e.\n",
                         "willReplaceOnChanges": true
                     },
                     "sourceableAttributes": {
@@ -10459,7 +10614,7 @@
             }
         },
         "rootly:index/apiKey:ApiKey": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.ApiKey \" pulumi-lang-dotnet=\"\nrootly.ApiKey \" pulumi-lang-go=\"\nApiKey \" pulumi-lang-python=\"\nApiKey \" pulumi-lang-yaml=\"\nrootly.ApiKey \" pulumi-lang-java=\"\nrootly.ApiKey \"\u003e\nrootly.ApiKey \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/apiKey:ApiKey primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_api_key\" \"ci_pipeline\" {\n  name       = \"CI Pipeline\"\n  expires_at = \"2027-01-01T00:00:00Z\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.ApiKey \" pulumi-lang-dotnet=\"\nrootly.ApiKey \" pulumi-lang-go=\"\nApiKey \" pulumi-lang-python=\"\nApiKey \" pulumi-lang-yaml=\"\nrootly.ApiKey \" pulumi-lang-java=\"\nrootly.ApiKey \"\u003e\nrootly.ApiKey \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/apiKey:ApiKey primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "description": {
                     "type": "string",
@@ -10672,7 +10827,7 @@
             }
         },
         "rootly:index/catalog:Catalog": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Catalog \" pulumi-lang-dotnet=\"\nrootly.Catalog \" pulumi-lang-go=\"\nCatalog \" pulumi-lang-python=\"\nCatalog \" pulumi-lang-yaml=\"\nrootly.Catalog \" pulumi-lang-java=\"\nrootly.Catalog \"\u003e\nrootly.Catalog \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/catalog:Catalog primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_catalog\" \"customer_tier\" {\n  name        = \"Customer Tier\"\n  description = \"Customer pricing tiers\"\n  kind        = \"service\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Catalog \" pulumi-lang-dotnet=\"\nrootly.Catalog \" pulumi-lang-go=\"\nCatalog \" pulumi-lang-python=\"\nCatalog \" pulumi-lang-yaml=\"\nrootly.Catalog \" pulumi-lang-java=\"\nrootly.Catalog \"\u003e\nrootly.Catalog \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/catalog:Catalog primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "description": {
                     "type": "string"
@@ -10732,7 +10887,7 @@
             }
         },
         "rootly:index/catalogChecklistTemplate:CatalogChecklistTemplate": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CatalogChecklistTemplate \" pulumi-lang-dotnet=\"\nrootly.CatalogChecklistTemplate \" pulumi-lang-go=\"\nCatalogChecklistTemplate \" pulumi-lang-python=\"\nCatalogChecklistTemplate \" pulumi-lang-yaml=\"\nrootly.CatalogChecklistTemplate \" pulumi-lang-java=\"\nrootly.CatalogChecklistTemplate \"\u003e\nrootly.CatalogChecklistTemplate \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/catalogChecklistTemplate:CatalogChecklistTemplate primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_catalog_checklist_template\" \"production_readiness\" {\n  catalog_id = rootly_catalog.customer_tier.id\n  name       = \"Production Readiness\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CatalogChecklistTemplate \" pulumi-lang-dotnet=\"\nrootly.CatalogChecklistTemplate \" pulumi-lang-go=\"\nCatalogChecklistTemplate \" pulumi-lang-python=\"\nCatalogChecklistTemplate \" pulumi-lang-yaml=\"\nrootly.CatalogChecklistTemplate \" pulumi-lang-java=\"\nrootly.CatalogChecklistTemplate \"\u003e\nrootly.CatalogChecklistTemplate \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/catalogChecklistTemplate:CatalogChecklistTemplate primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "catalogType": {
                     "type": "string",
@@ -10865,7 +11020,7 @@
             }
         },
         "rootly:index/catalogEntity:CatalogEntity": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CatalogEntity \" pulumi-lang-dotnet=\"\nrootly.CatalogEntity \" pulumi-lang-go=\"\nCatalogEntity \" pulumi-lang-python=\"\nCatalogEntity \" pulumi-lang-yaml=\"\nrootly.CatalogEntity \" pulumi-lang-java=\"\nrootly.CatalogEntity \"\u003e\nrootly.CatalogEntity \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/catalogEntity:CatalogEntity primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_catalog_entity\" \"enterprise_tier\" {\n  catalog_id  = rootly_catalog.customer_tier.id\n  name        = \"Enterprise\"\n  description = \"Enterprise customer tier\"\n}\n\nresource \"rootly_catalog_entity\" \"growth_tier\" {\n  catalog_id  = rootly_catalog.customer_tier.id\n  name        = \"Growth\"\n  description = \"Growth customer tier\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CatalogEntity \" pulumi-lang-dotnet=\"\nrootly.CatalogEntity \" pulumi-lang-go=\"\nCatalogEntity \" pulumi-lang-python=\"\nCatalogEntity \" pulumi-lang-yaml=\"\nrootly.CatalogEntity \" pulumi-lang-java=\"\nrootly.CatalogEntity \"\u003e\nrootly.CatalogEntity \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/catalogEntity:CatalogEntity primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "backstageId": {
                     "type": "string",
@@ -10962,7 +11117,7 @@
             }
         },
         "rootly:index/catalogProperty:CatalogProperty": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CatalogProperty \" pulumi-lang-dotnet=\"\nrootly.CatalogProperty \" pulumi-lang-go=\"\nCatalogProperty \" pulumi-lang-python=\"\nCatalogProperty \" pulumi-lang-yaml=\"\nrootly.CatalogProperty \" pulumi-lang-java=\"\nrootly.CatalogProperty \"\u003e\nrootly.CatalogProperty \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/catalogProperty:CatalogProperty primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_catalog_property\" \"support_level\" {\n  catalog_id = rootly_catalog.customer_tier.id\n  name       = \"Support Level\"\n  kind       = \"select\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CatalogProperty \" pulumi-lang-dotnet=\"\nrootly.CatalogProperty \" pulumi-lang-go=\"\nCatalogProperty \" pulumi-lang-python=\"\nCatalogProperty \" pulumi-lang-yaml=\"\nrootly.CatalogProperty \" pulumi-lang-java=\"\nrootly.CatalogProperty \"\u003e\nrootly.CatalogProperty \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/catalogProperty:CatalogProperty primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "catalogId": {
                     "type": "string"
@@ -11072,7 +11227,7 @@
             }
         },
         "rootly:index/cause:Cause": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Cause \" pulumi-lang-dotnet=\"\nrootly.Cause \" pulumi-lang-go=\"\nCause \" pulumi-lang-python=\"\nCause \" pulumi-lang-yaml=\"\nrootly.Cause \" pulumi-lang-java=\"\nrootly.Cause \"\u003e\nrootly.Cause \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/cause:Cause primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_cause\" \"bad_deploy\" {\n  name        = \"Bad Deploy\"\n  description = \"Incident caused by a faulty deployment\"\n}\n\nresource \"rootly_cause\" \"infrastructure_failure\" {\n  name        = \"Infrastructure Failure\"\n  description = \"Hardware or cloud provider issue\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Cause \" pulumi-lang-dotnet=\"\nrootly.Cause \" pulumi-lang-go=\"\nCause \" pulumi-lang-python=\"\nCause \" pulumi-lang-yaml=\"\nrootly.Cause \" pulumi-lang-java=\"\nrootly.Cause \"\u003e\nrootly.Cause \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/cause:Cause primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "description": {
                     "type": "string",
@@ -11160,7 +11315,7 @@
             }
         },
         "rootly:index/communicationsGroup:CommunicationsGroup": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CommunicationsGroup \" pulumi-lang-dotnet=\"\nrootly.CommunicationsGroup \" pulumi-lang-go=\"\nCommunicationsGroup \" pulumi-lang-python=\"\nCommunicationsGroup \" pulumi-lang-yaml=\"\nrootly.CommunicationsGroup \" pulumi-lang-java=\"\nrootly.CommunicationsGroup \"\u003e\nrootly.CommunicationsGroup \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/communicationsGroup:CommunicationsGroup primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_communications_group\" \"executive_stakeholders\" {\n  name = \"Executive Stakeholders\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CommunicationsGroup \" pulumi-lang-dotnet=\"\nrootly.CommunicationsGroup \" pulumi-lang-go=\"\nCommunicationsGroup \" pulumi-lang-python=\"\nCommunicationsGroup \" pulumi-lang-yaml=\"\nrootly.CommunicationsGroup \" pulumi-lang-java=\"\nrootly.CommunicationsGroup \"\u003e\nrootly.CommunicationsGroup \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/communicationsGroup:CommunicationsGroup primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "communicationExternalGroupMembers": {
                     "type": "array",
@@ -11344,7 +11499,7 @@
             }
         },
         "rootly:index/communicationsStage:CommunicationsStage": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CommunicationsStage \" pulumi-lang-dotnet=\"\nrootly.CommunicationsStage \" pulumi-lang-go=\"\nCommunicationsStage \" pulumi-lang-python=\"\nCommunicationsStage \" pulumi-lang-yaml=\"\nrootly.CommunicationsStage \" pulumi-lang-java=\"\nrootly.CommunicationsStage \"\u003e\nrootly.CommunicationsStage \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/communicationsStage:CommunicationsStage primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_communications_stage\" \"initial_notification\" {\n  name     = \"Initial Notification\"\n  position = 1\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CommunicationsStage \" pulumi-lang-dotnet=\"\nrootly.CommunicationsStage \" pulumi-lang-go=\"\nCommunicationsStage \" pulumi-lang-python=\"\nCommunicationsStage \" pulumi-lang-yaml=\"\nrootly.CommunicationsStage \" pulumi-lang-java=\"\nrootly.CommunicationsStage \"\u003e\nrootly.CommunicationsStage \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/communicationsStage:CommunicationsStage primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "description": {
                     "type": "string",
@@ -11411,7 +11566,7 @@
             }
         },
         "rootly:index/communicationsTemplate:CommunicationsTemplate": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CommunicationsTemplate \" pulumi-lang-dotnet=\"\nrootly.CommunicationsTemplate \" pulumi-lang-go=\"\nCommunicationsTemplate \" pulumi-lang-python=\"\nCommunicationsTemplate \" pulumi-lang-yaml=\"\nrootly.CommunicationsTemplate \" pulumi-lang-java=\"\nrootly.CommunicationsTemplate \"\u003e\nrootly.CommunicationsTemplate \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/communicationsTemplate:CommunicationsTemplate primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_communications_template\" \"status_update\" {\n  name = \"Incident Status Update\"\n  body = \"**Incident:** {{ incident.title }}\\n**Status:** {{ incident.status }}\\n**Summary:** {{ incident.summary }}\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CommunicationsTemplate \" pulumi-lang-dotnet=\"\nrootly.CommunicationsTemplate \" pulumi-lang-go=\"\nCommunicationsTemplate \" pulumi-lang-python=\"\nCommunicationsTemplate \" pulumi-lang-yaml=\"\nrootly.CommunicationsTemplate \" pulumi-lang-java=\"\nrootly.CommunicationsTemplate \"\u003e\nrootly.CommunicationsTemplate \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/communicationsTemplate:CommunicationsTemplate primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "communicationTemplateStages": {
                     "type": "array",
@@ -11528,7 +11683,7 @@
             }
         },
         "rootly:index/communicationsType:CommunicationsType": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CommunicationsType \" pulumi-lang-dotnet=\"\nrootly.CommunicationsType \" pulumi-lang-go=\"\nCommunicationsType \" pulumi-lang-python=\"\nCommunicationsType \" pulumi-lang-yaml=\"\nrootly.CommunicationsType \" pulumi-lang-java=\"\nrootly.CommunicationsType \"\u003e\nrootly.CommunicationsType \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/communicationsType:CommunicationsType primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_communications_type\" \"slack_notification\" {\n  name = \"Slack Notification\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CommunicationsType \" pulumi-lang-dotnet=\"\nrootly.CommunicationsType \" pulumi-lang-go=\"\nCommunicationsType \" pulumi-lang-python=\"\nCommunicationsType \" pulumi-lang-yaml=\"\nrootly.CommunicationsType \" pulumi-lang-java=\"\nrootly.CommunicationsType \"\u003e\nrootly.CommunicationsType \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/communicationsType:CommunicationsType primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "color": {
                     "type": "string",
@@ -11611,7 +11766,7 @@
             }
         },
         "rootly:index/customField:CustomField": {
-            "description": "DEPRECATED: Please use \u003cspan pulumi-lang-nodejs=\"`rootly.FormField`\" pulumi-lang-dotnet=\"`rootly.FormField`\" pulumi-lang-go=\"`FormField`\" pulumi-lang-python=\"`FormField`\" pulumi-lang-yaml=\"`rootly.FormField`\" pulumi-lang-java=\"`rootly.FormField`\"\u003e`rootly.FormField`\u003c/span\u003e resource instead.\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CustomField \" pulumi-lang-dotnet=\"\nrootly.CustomField \" pulumi-lang-go=\"\nCustomField \" pulumi-lang-python=\"\nCustomField \" pulumi-lang-yaml=\"\nrootly.CustomField \" pulumi-lang-java=\"\nrootly.CustomField \"\u003e\nrootly.CustomField \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/customField:CustomField primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "DEPRECATED: Please use \u003cspan pulumi-lang-nodejs=\"`rootly.FormField`\" pulumi-lang-dotnet=\"`rootly.FormField`\" pulumi-lang-go=\"`FormField`\" pulumi-lang-python=\"`FormField`\" pulumi-lang-yaml=\"`rootly.FormField`\" pulumi-lang-java=\"`rootly.FormField`\"\u003e`rootly.FormField`\u003c/span\u003e resource instead.\n\n## Example Usage\n\n```shell\nresource \"rootly_custom_field\" \"affected_region\" {\n  label   = \"Affected Region\"\n  kind    = \"select\"\n  enabled = true\n  shown   = [\"incident_form\", \"incident_post_mortem\"]\n}\n\nresource \"rootly_custom_field_option\" \"us_east_1\" {\n  custom_field_id = rootly_custom_field.affected_region.id\n  value           = \"us-east-1\"\n  color           = \"#047BF8\"\n}\n\nresource \"rootly_custom_field_option\" \"eu_west_1\" {\n  custom_field_id = rootly_custom_field.affected_region.id\n  value           = \"eu-west-1\"\n  color           = \"#FFA500\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CustomField \" pulumi-lang-dotnet=\"\nrootly.CustomField \" pulumi-lang-go=\"\nCustomField \" pulumi-lang-python=\"\nCustomField \" pulumi-lang-yaml=\"\nrootly.CustomField \" pulumi-lang-java=\"\nrootly.CustomField \"\u003e\nrootly.CustomField \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/customField:CustomField primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "default": {
                     "type": "string",
@@ -11754,7 +11909,7 @@
             }
         },
         "rootly:index/customFieldOption:CustomFieldOption": {
-            "description": "DEPRECATED: Please use \u003cspan pulumi-lang-nodejs=\"`rootly.FormField`\" pulumi-lang-dotnet=\"`rootly.FormField`\" pulumi-lang-go=\"`FormField`\" pulumi-lang-python=\"`FormField`\" pulumi-lang-yaml=\"`rootly.FormField`\" pulumi-lang-java=\"`rootly.FormField`\"\u003e`rootly.FormField`\u003c/span\u003e and \u003cspan pulumi-lang-nodejs=\"`rootly.FormFieldOption`\" pulumi-lang-dotnet=\"`rootly.FormFieldOption`\" pulumi-lang-go=\"`FormFieldOption`\" pulumi-lang-python=\"`FormFieldOption`\" pulumi-lang-yaml=\"`rootly.FormFieldOption`\" pulumi-lang-java=\"`rootly.FormFieldOption`\"\u003e`rootly.FormFieldOption`\u003c/span\u003e resources instead.\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CustomFieldOption \" pulumi-lang-dotnet=\"\nrootly.CustomFieldOption \" pulumi-lang-go=\"\nCustomFieldOption \" pulumi-lang-python=\"\nCustomFieldOption \" pulumi-lang-yaml=\"\nrootly.CustomFieldOption \" pulumi-lang-java=\"\nrootly.CustomFieldOption \"\u003e\nrootly.CustomFieldOption \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/customFieldOption:CustomFieldOption primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "DEPRECATED: Please use \u003cspan pulumi-lang-nodejs=\"`rootly.FormField`\" pulumi-lang-dotnet=\"`rootly.FormField`\" pulumi-lang-go=\"`FormField`\" pulumi-lang-python=\"`FormField`\" pulumi-lang-yaml=\"`rootly.FormField`\" pulumi-lang-java=\"`rootly.FormField`\"\u003e`rootly.FormField`\u003c/span\u003e and \u003cspan pulumi-lang-nodejs=\"`rootly.FormFieldOption`\" pulumi-lang-dotnet=\"`rootly.FormFieldOption`\" pulumi-lang-go=\"`FormFieldOption`\" pulumi-lang-python=\"`FormFieldOption`\" pulumi-lang-yaml=\"`rootly.FormFieldOption`\" pulumi-lang-java=\"`rootly.FormFieldOption`\"\u003e`rootly.FormFieldOption`\u003c/span\u003e resources instead.\n\n## Example Usage\n\n```shell\nresource \"rootly_custom_field_option\" \"us_west_2\" {\n  custom_field_id = rootly_custom_field.affected_region.id\n  value           = \"us-west-2\"\n  color           = \"#00AA00\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.CustomFieldOption \" pulumi-lang-dotnet=\"\nrootly.CustomFieldOption \" pulumi-lang-go=\"\nCustomFieldOption \" pulumi-lang-python=\"\nCustomFieldOption \" pulumi-lang-yaml=\"\nrootly.CustomFieldOption \" pulumi-lang-java=\"\nrootly.CustomFieldOption \"\u003e\nrootly.CustomFieldOption \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/customFieldOption:CustomFieldOption primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "color": {
                     "type": "string",
@@ -12049,7 +12204,7 @@
             }
         },
         "rootly:index/edgeConnector:EdgeConnector": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.EdgeConnector \" pulumi-lang-dotnet=\"\nrootly.EdgeConnector \" pulumi-lang-go=\"\nEdgeConnector \" pulumi-lang-python=\"\nEdgeConnector \" pulumi-lang-yaml=\"\nrootly.EdgeConnector \" pulumi-lang-java=\"\nrootly.EdgeConnector \"\u003e\nrootly.EdgeConnector \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/edgeConnector:EdgeConnector primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_edge_connector\" \"us_east_datacenter\" {\n  name = \"US-East Datacenter\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.EdgeConnector \" pulumi-lang-dotnet=\"\nrootly.EdgeConnector \" pulumi-lang-go=\"\nEdgeConnector \" pulumi-lang-python=\"\nEdgeConnector \" pulumi-lang-yaml=\"\nrootly.EdgeConnector \" pulumi-lang-java=\"\nrootly.EdgeConnector \"\u003e\nrootly.EdgeConnector \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/edgeConnector:EdgeConnector primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "createdAt": {
                     "type": "string"
@@ -13797,14 +13952,18 @@
                 "color",
                 "cortexId",
                 "description",
+                "environmentIds",
                 "escalationPolicyId",
                 "externalId",
                 "name",
                 "opsgenieId",
                 "opsgenieTeamId",
+                "ownerGroupIds",
+                "ownerUserIds",
                 "pagerdutyId",
                 "position",
                 "publicDescription",
+                "serviceIds",
                 "serviceNowCiSysId",
                 "slug"
             ],
@@ -14042,7 +14201,7 @@
             }
         },
         "rootly:index/heartbeat:Heartbeat": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Heartbeat \" pulumi-lang-dotnet=\"\nrootly.Heartbeat \" pulumi-lang-go=\"\nHeartbeat \" pulumi-lang-python=\"\nHeartbeat \" pulumi-lang-yaml=\"\nrootly.Heartbeat \" pulumi-lang-java=\"\nrootly.Heartbeat \"\u003e\nrootly.Heartbeat \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/heartbeat:Heartbeat primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_heartbeat\" \"nightly_backup\" {\n  name                     = \"nightly-db-backup\"\n  description              = \"Nightly database backup cron job\"\n  interval                 = 24\n  interval_unit            = \"hours\"\n  alert_summary            = \"Nightly backup missed\"\n  notification_target_type = \"Service\"\n  notification_target_id   = rootly_service.elasticsearch_prod.id\n  enabled                  = true\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Heartbeat \" pulumi-lang-dotnet=\"\nrootly.Heartbeat \" pulumi-lang-go=\"\nHeartbeat \" pulumi-lang-python=\"\nHeartbeat \" pulumi-lang-yaml=\"\nrootly.Heartbeat \" pulumi-lang-java=\"\nrootly.Heartbeat \"\u003e\nrootly.Heartbeat \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/heartbeat:Heartbeat primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "alertDescription": {
                     "type": "string",
@@ -14495,7 +14654,7 @@
             }
         },
         "rootly:index/incidentRole:IncidentRole": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.IncidentRole \" pulumi-lang-dotnet=\"\nrootly.IncidentRole \" pulumi-lang-go=\"\nIncidentRole \" pulumi-lang-python=\"\nIncidentRole \" pulumi-lang-yaml=\"\nrootly.IncidentRole \" pulumi-lang-java=\"\nrootly.IncidentRole \"\u003e\nrootly.IncidentRole \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/incidentRole:IncidentRole primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_incident_role\" \"incident_commander\" {\n  name        = \"Incident Commander\"\n  summary     = \"Leads the incident response\"\n  description = \"Coordinates response, delegates tasks, makes decisions\"\n  enabled     = true\n}\n\nresource \"rootly_incident_role\" \"communications_lead\" {\n  name     = \"Communications Lead\"\n  summary  = \"Manages stakeholder communications\"\n  optional = true\n  enabled  = true\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.IncidentRole \" pulumi-lang-dotnet=\"\nrootly.IncidentRole \" pulumi-lang-go=\"\nIncidentRole \" pulumi-lang-python=\"\nIncidentRole \" pulumi-lang-yaml=\"\nrootly.IncidentRole \" pulumi-lang-java=\"\nrootly.IncidentRole \"\u003e\nrootly.IncidentRole \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/incidentRole:IncidentRole primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "allowMultiUserAssignment": {
                     "type": "boolean",
@@ -14610,7 +14769,7 @@
             }
         },
         "rootly:index/incidentRoleTask:IncidentRoleTask": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.IncidentRoleTask \" pulumi-lang-dotnet=\"\nrootly.IncidentRoleTask \" pulumi-lang-go=\"\nIncidentRoleTask \" pulumi-lang-python=\"\nIncidentRoleTask \" pulumi-lang-yaml=\"\nrootly.IncidentRoleTask \" pulumi-lang-java=\"\nrootly.IncidentRoleTask \"\u003e\nrootly.IncidentRoleTask \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/incidentRoleTask:IncidentRoleTask primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_incident_role_task\" \"open_war_room\" {\n  incident_role_id = rootly_incident_role.incident_commander.id\n  task             = \"Open a war room and invite responders\"\n  priority         = \"high\"\n}\n\nresource \"rootly_incident_role_task\" \"send_status_update\" {\n  incident_role_id = rootly_incident_role.communications_lead.id\n  task             = \"Send initial status update to stakeholders\"\n  priority         = \"high\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.IncidentRoleTask \" pulumi-lang-dotnet=\"\nrootly.IncidentRoleTask \" pulumi-lang-go=\"\nIncidentRoleTask \" pulumi-lang-python=\"\nIncidentRoleTask \" pulumi-lang-yaml=\"\nrootly.IncidentRoleTask \" pulumi-lang-java=\"\nrootly.IncidentRoleTask \"\u003e\nrootly.IncidentRoleTask \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/incidentRoleTask:IncidentRoleTask primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "description": {
                     "type": "string",
@@ -14678,7 +14837,7 @@
             }
         },
         "rootly:index/incidentSubStatus:IncidentSubStatus": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.IncidentSubStatus \" pulumi-lang-dotnet=\"\nrootly.IncidentSubStatus \" pulumi-lang-go=\"\nIncidentSubStatus \" pulumi-lang-python=\"\nIncidentSubStatus \" pulumi-lang-yaml=\"\nrootly.IncidentSubStatus \" pulumi-lang-java=\"\nrootly.IncidentSubStatus \"\u003e\nrootly.IncidentSubStatus \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/incidentSubStatus:IncidentSubStatus primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_incident_sub_status\" \"investigating\" {\n  incident_id   = data.rootly_incident.outage.id\n  sub_status_id = rootly_sub_status.investigating.id\n  assigned_at   = \"2026-06-01T00:00:00Z\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.IncidentSubStatus \" pulumi-lang-dotnet=\"\nrootly.IncidentSubStatus \" pulumi-lang-go=\"\nIncidentSubStatus \" pulumi-lang-python=\"\nIncidentSubStatus \" pulumi-lang-yaml=\"\nrootly.IncidentSubStatus \" pulumi-lang-java=\"\nrootly.IncidentSubStatus \"\u003e\nrootly.IncidentSubStatus \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/incidentSubStatus:IncidentSubStatus primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "assignedAt": {
                     "type": "string"
@@ -14742,7 +14901,7 @@
             }
         },
         "rootly:index/incidentType:IncidentType": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.IncidentType \" pulumi-lang-dotnet=\"\nrootly.IncidentType \" pulumi-lang-go=\"\nIncidentType \" pulumi-lang-python=\"\nIncidentType \" pulumi-lang-yaml=\"\nrootly.IncidentType \" pulumi-lang-java=\"\nrootly.IncidentType \"\u003e\nrootly.IncidentType \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/incidentType:IncidentType primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_incident_type\" \"security_breach\" {\n  name        = \"Security Breach\"\n  description = \"Unauthorized access or data exposure incidents\"\n  color       = \"#FF0000\"\n}\n\nresource \"rootly_incident_type\" \"service_degradation\" {\n  name        = \"Service Degradation\"\n  description = \"Partial or full service outage affecting customers\"\n  color       = \"#FFA500\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.IncidentType \" pulumi-lang-dotnet=\"\nrootly.IncidentType \" pulumi-lang-go=\"\nIncidentType \" pulumi-lang-python=\"\nIncidentType \" pulumi-lang-yaml=\"\nrootly.IncidentType \" pulumi-lang-java=\"\nrootly.IncidentType \"\u003e\nrootly.IncidentType \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/incidentType:IncidentType primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "color": {
                     "type": "string",
@@ -15153,7 +15312,7 @@
             }
         },
         "rootly:index/onCallRole:OnCallRole": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.OnCallRole \" pulumi-lang-dotnet=\"\nrootly.OnCallRole \" pulumi-lang-go=\"\nOnCallRole \" pulumi-lang-python=\"\nOnCallRole \" pulumi-lang-yaml=\"\nrootly.OnCallRole \" pulumi-lang-java=\"\nrootly.OnCallRole \"\u003e\nrootly.OnCallRole \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/onCallRole:OnCallRole primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_on_call_role\" \"custom\" {\n  name = \"Custom On-Call Role\"\n\n  alerts_permissions = [\n    \"create\",\n    \"update\",\n    \"read\",\n  ]\n  escalation_policies_permissions = [\n    \"create\",\n    \"read\",\n    \"update\",\n    \"delete\",\n  ]\n  schedules_permissions = [\n    \"read\",\n    \"update\",\n  ]\n  schedule_override_permissions = [\n    \"create\",\n    \"update\",\n  ]\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.OnCallRole \" pulumi-lang-dotnet=\"\nrootly.OnCallRole \" pulumi-lang-go=\"\nOnCallRole \" pulumi-lang-python=\"\nOnCallRole \" pulumi-lang-yaml=\"\nrootly.OnCallRole \" pulumi-lang-java=\"\nrootly.OnCallRole \"\u003e\nrootly.OnCallRole \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/onCallRole:OnCallRole primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nYou can also import by slug:\n\n```sh\n$ pulumi import rootly:index/onCallRole:OnCallRole primary my-oncall-role-slug\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id by listing on-call roles through the API (`GET /v1/on_call_roles`), as role IDs are not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "alertFieldsPermissions": {
                     "type": "array",
@@ -15690,7 +15849,7 @@
             }
         },
         "rootly:index/onCallShadow:OnCallShadow": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.OnCallShadow \" pulumi-lang-dotnet=\"\nrootly.OnCallShadow \" pulumi-lang-go=\"\nOnCallShadow \" pulumi-lang-python=\"\nOnCallShadow \" pulumi-lang-yaml=\"\nrootly.OnCallShadow \" pulumi-lang-java=\"\nrootly.OnCallShadow \"\u003e\nrootly.OnCallShadow \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/onCallShadow:OnCallShadow primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_on_call_shadow\" \"new_hire_shadow\" {\n  schedule_id     = rootly_schedule.primary_oncall.id\n  shadow_user_id  = data.rootly_user.new_hire.id\n  shadowable_id   = data.rootly_user.senior_engineer.id\n  shadowable_type = \"User\"\n  starts_at       = \"2026-06-01T00:00:00Z\"\n  ends_at         = \"2026-06-14T00:00:00Z\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.OnCallShadow \" pulumi-lang-dotnet=\"\nrootly.OnCallShadow \" pulumi-lang-go=\"\nOnCallShadow \" pulumi-lang-python=\"\nOnCallShadow \" pulumi-lang-yaml=\"\nrootly.OnCallShadow \" pulumi-lang-java=\"\nrootly.OnCallShadow \"\u003e\nrootly.OnCallShadow \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/onCallShadow:OnCallShadow primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "endsAt": {
                     "type": "string",
@@ -15881,7 +16040,7 @@
             }
         },
         "rootly:index/playbook:Playbook": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Playbook \" pulumi-lang-dotnet=\"\nrootly.Playbook \" pulumi-lang-go=\"\nPlaybook \" pulumi-lang-python=\"\nPlaybook \" pulumi-lang-yaml=\"\nrootly.Playbook \" pulumi-lang-java=\"\nrootly.Playbook \"\u003e\nrootly.Playbook \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/playbook:Playbook primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_playbook\" \"database_outage\" {\n  title        = \"Database Outage Response\"\n  summary      = \"Steps to follow when a database outage occurs\"\n  severity_ids = [rootly_severity.sev0.id, rootly_severity.sev1.id]\n  service_ids  = [rootly_service.elasticsearch_prod.id]\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Playbook \" pulumi-lang-dotnet=\"\nrootly.Playbook \" pulumi-lang-go=\"\nPlaybook \" pulumi-lang-python=\"\nPlaybook \" pulumi-lang-yaml=\"\nrootly.Playbook \" pulumi-lang-java=\"\nrootly.Playbook \"\u003e\nrootly.Playbook \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/playbook:Playbook primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "environmentIds": {
                     "type": "array",
@@ -15939,7 +16098,13 @@
                 }
             },
             "required": [
+                "environmentIds",
                 "externalUrl",
+                "functionalityIds",
+                "groupIds",
+                "incidentTypeIds",
+                "serviceIds",
+                "severityIds",
                 "summary",
                 "title"
             ],
@@ -16064,7 +16229,7 @@
             }
         },
         "rootly:index/playbookTask:PlaybookTask": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.PlaybookTask \" pulumi-lang-dotnet=\"\nrootly.PlaybookTask \" pulumi-lang-go=\"\nPlaybookTask \" pulumi-lang-python=\"\nPlaybookTask \" pulumi-lang-yaml=\"\nrootly.PlaybookTask \" pulumi-lang-java=\"\nrootly.PlaybookTask \"\u003e\nrootly.PlaybookTask \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/playbookTask:PlaybookTask primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_playbook_task\" \"check_dashboards\" {\n  playbook_id = rootly_playbook.database_outage.id\n  task        = \"Check Grafana dashboards for anomalies\"\n}\n\nresource \"rootly_playbook_task\" \"notify_dba\" {\n  playbook_id = rootly_playbook.database_outage.id\n  task        = \"Notify DBA on-call via Slack\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.PlaybookTask \" pulumi-lang-dotnet=\"\nrootly.PlaybookTask \" pulumi-lang-go=\"\nPlaybookTask \" pulumi-lang-python=\"\nPlaybookTask \" pulumi-lang-yaml=\"\nrootly.PlaybookTask \" pulumi-lang-java=\"\nrootly.PlaybookTask \"\u003e\nrootly.PlaybookTask \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/playbookTask:PlaybookTask primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "description": {
                     "type": "string",
@@ -16133,7 +16298,7 @@
             }
         },
         "rootly:index/postMortemTemplate:PostMortemTemplate": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.PostMortemTemplate \" pulumi-lang-dotnet=\"\nrootly.PostMortemTemplate \" pulumi-lang-go=\"\nPostMortemTemplate \" pulumi-lang-python=\"\nPostMortemTemplate \" pulumi-lang-yaml=\"\nrootly.PostMortemTemplate \" pulumi-lang-java=\"\nrootly.PostMortemTemplate \"\u003e\nrootly.PostMortemTemplate \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/postMortemTemplate:PostMortemTemplate primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_post_mortem_template\" \"default\" {\n  name    = \"Standard Post-Mortem\"\n  default = true\n  format  = \"markdown\"\n  content = \u003c\u003c-EOT\n## Incident Summary\n{{ incident.title }}\n\n## Timeline\n{{ incident.timeline }}\n\n## Root Cause\n_To be filled in_\n\n## Action Items\n{{ incident.action_items }}\nEOT\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.PostMortemTemplate \" pulumi-lang-dotnet=\"\nrootly.PostMortemTemplate \" pulumi-lang-go=\"\nPostMortemTemplate \" pulumi-lang-python=\"\nPostMortemTemplate \" pulumi-lang-yaml=\"\nrootly.PostMortemTemplate \" pulumi-lang-java=\"\nrootly.PostMortemTemplate \"\u003e\nrootly.PostMortemTemplate \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/postMortemTemplate:PostMortemTemplate primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "content": {
                     "type": "string",
@@ -16597,7 +16762,7 @@
             }
         },
         "rootly:index/role:Role": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Role \" pulumi-lang-dotnet=\"\nrootly.Role \" pulumi-lang-go=\"\nRole \" pulumi-lang-python=\"\nRole \" pulumi-lang-yaml=\"\nrootly.Role \" pulumi-lang-java=\"\nrootly.Role \"\u003e\nrootly.Role \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/role:Role primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_role\" \"custom\" {\n  name = \"Custom Rootly Role\"\n\n  incidents_permissions = [\n    \"read\",\n    \"update\",\n  ]\n  incident_feedbacks_permissions = [\n    \"create\",\n    \"read\",\n  ]\n  services_permissions = [\n    \"read\",\n  ]\n  severities_permissions = [\n    \"read\",\n  ]\n\n  is_editable  = true\n  is_deletable = true\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Role \" pulumi-lang-dotnet=\"\nrootly.Role \" pulumi-lang-go=\"\nRole \" pulumi-lang-python=\"\nRole \" pulumi-lang-yaml=\"\nrootly.Role \" pulumi-lang-java=\"\nrootly.Role \"\u003e\nrootly.Role \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/role:Role primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nYou can also import by slug:\n\n```sh\n$ pulumi import rootly:index/role:Role primary my-role-slug\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id by listing roles through the API (`GET /v1/roles`), as role IDs are not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "alertsPermissions": {
                     "type": "array",
@@ -17426,7 +17591,7 @@
                 },
                 "ownerUserId": {
                     "type": "integer",
-                    "description": "ID of user assigned as owner of the schedule\n"
+                    "description": "ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.\n"
                 },
                 "slackChannel": {
                     "type": "object",
@@ -17471,7 +17636,7 @@
                 },
                 "ownerUserId": {
                     "type": "integer",
-                    "description": "ID of user assigned as owner of the schedule\n"
+                    "description": "ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.\n"
                 },
                 "slackChannel": {
                     "type": "object",
@@ -17512,7 +17677,7 @@
                     },
                     "ownerUserId": {
                         "type": "integer",
-                        "description": "ID of user assigned as owner of the schedule\n"
+                        "description": "ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.\n"
                     },
                     "slackChannel": {
                         "type": "object",
@@ -17877,7 +18042,7 @@
             }
         },
         "rootly:index/secret:Secret": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Secret \" pulumi-lang-dotnet=\"\nrootly.Secret \" pulumi-lang-go=\"\nSecret \" pulumi-lang-python=\"\nSecret \" pulumi-lang-yaml=\"\nrootly.Secret \" pulumi-lang-java=\"\nrootly.Secret \"\u003e\nrootly.Secret \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/secret:Secret primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_secret\" \"pagerduty_api_token\" {\n  name   = \"pagerduty_api_token\"\n  secret = var.pagerduty_api_token\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.Secret \" pulumi-lang-dotnet=\"\nrootly.Secret \" pulumi-lang-go=\"\nSecret \" pulumi-lang-python=\"\nSecret \" pulumi-lang-yaml=\"\nrootly.Secret \" pulumi-lang-java=\"\nrootly.Secret \"\u003e\nrootly.Secret \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/secret:Secret primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "hashicorpVaultMount": {
                     "type": "string",
@@ -18126,6 +18291,7 @@
                 "alertsEmailEnabled",
                 "color",
                 "description",
+                "environmentIds",
                 "escalationPolicyId",
                 "githubRepositoryBranch",
                 "githubRepositoryName",
@@ -18135,8 +18301,11 @@
                 "incidentBroadcastEnabled",
                 "kubernetesDeploymentName",
                 "name",
+                "ownerGroupIds",
+                "ownerUserIds",
                 "position",
                 "publicDescription",
+                "serviceIds",
                 "slug"
             ],
             "inputProperties": {
@@ -18885,7 +19054,7 @@
             }
         },
         "rootly:index/statusPage:StatusPage": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.StatusPage \" pulumi-lang-dotnet=\"\nrootly.StatusPage \" pulumi-lang-go=\"\nStatusPage \" pulumi-lang-python=\"\nStatusPage \" pulumi-lang-yaml=\"\nrootly.StatusPage \" pulumi-lang-java=\"\nrootly.StatusPage \"\u003e\nrootly.StatusPage \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/statusPage:StatusPage primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_status_page\" \"public\" {\n  title                 = \"Acme Status\"\n  public_title          = \"Acme System Status\"\n  description           = \"Current status of Acme services\"\n  success_message       = \"All Systems Operational\"\n  failure_message       = \"Degraded Performance\"\n  show_uptime           = true\n  show_uptime_last_days = 90\n  service_ids           = [rootly_service.elasticsearch_prod.id]\n  functionality_ids     = [rootly_functionality.checkout.id]\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.StatusPage \" pulumi-lang-dotnet=\"\nrootly.StatusPage \" pulumi-lang-go=\"\nStatusPage \" pulumi-lang-python=\"\nStatusPage \" pulumi-lang-yaml=\"\nrootly.StatusPage \" pulumi-lang-java=\"\nrootly.StatusPage \"\u003e\nrootly.StatusPage \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/statusPage:StatusPage primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "allowSearchEngineIndex": {
                     "type": "boolean",
@@ -18902,6 +19071,13 @@
                 "authenticationPassword": {
                     "type": "string",
                     "description": "Authentication password\n"
+                },
+                "cnameRecords": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "CNAME records mapping external domain names to their DNS target values. Populated asynchronously after setting external*domain*names.\n"
                 },
                 "description": {
                     "type": "string",
@@ -19027,6 +19203,7 @@
                 "allowSearchEngineIndex",
                 "authenticationEnabled",
                 "authenticationPassword",
+                "cnameRecords",
                 "description",
                 "failureMessage",
                 "footerColor",
@@ -19208,6 +19385,13 @@
                     "authenticationPassword": {
                         "type": "string",
                         "description": "Authentication password\n"
+                    },
+                    "cnameRecords": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "CNAME records mapping external domain names to their DNS target values. Populated asynchronously after setting external*domain*names.\n"
                     },
                     "description": {
                         "type": "string",
@@ -19463,7 +19647,7 @@
             }
         },
         "rootly:index/subStatus:SubStatus": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.SubStatus \" pulumi-lang-dotnet=\"\nrootly.SubStatus \" pulumi-lang-go=\"\nSubStatus \" pulumi-lang-python=\"\nSubStatus \" pulumi-lang-yaml=\"\nrootly.SubStatus \" pulumi-lang-java=\"\nrootly.SubStatus \"\u003e\nrootly.SubStatus \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/subStatus:SubStatus primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_sub_status\" \"investigating\" {\n  name          = \"Investigating\"\n  parent_status = \"started\"\n  description   = \"Responders are investigating\"\n}\n\nresource \"rootly_sub_status\" \"fix_in_progress\" {\n  name          = \"Fix In Progress\"\n  parent_status = \"started\"\n  description   = \"A fix is being implemented\"\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.SubStatus \" pulumi-lang-dotnet=\"\nrootly.SubStatus \" pulumi-lang-go=\"\nSubStatus \" pulumi-lang-python=\"\nSubStatus \" pulumi-lang-yaml=\"\nrootly.SubStatus \" pulumi-lang-java=\"\nrootly.SubStatus \"\u003e\nrootly.SubStatus \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/subStatus:SubStatus primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "description": {
                     "type": "string"
@@ -19930,7 +20114,7 @@
             }
         },
         "rootly:index/webhooksEndpoint:WebhooksEndpoint": {
-            "description": "\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.WebhooksEndpoint \" pulumi-lang-dotnet=\"\nrootly.WebhooksEndpoint \" pulumi-lang-go=\"\nWebhooksEndpoint \" pulumi-lang-python=\"\nWebhooksEndpoint \" pulumi-lang-yaml=\"\nrootly.WebhooksEndpoint \" pulumi-lang-java=\"\nrootly.WebhooksEndpoint \"\u003e\nrootly.WebhooksEndpoint \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/webhooksEndpoint:WebhooksEndpoint primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
+            "description": "## Example Usage\n\n```shell\nresource \"rootly_webhooks_endpoint\" \"datadog_events\" {\n  name        = \"Datadog Events\"\n  url         = \"https://app.datadoghq.com/api/v1/events\"\n  enabled     = true\n  event_types = [\"incident.created\", \"incident.resolved\"]\n}\n```\n\n## Import\n\u003cspan pulumi-lang-nodejs=\"\nrootly.WebhooksEndpoint \" pulumi-lang-dotnet=\"\nrootly.WebhooksEndpoint \" pulumi-lang-go=\"\nWebhooksEndpoint \" pulumi-lang-python=\"\nWebhooksEndpoint \" pulumi-lang-yaml=\"\nrootly.WebhooksEndpoint \" pulumi-lang-java=\"\nrootly.WebhooksEndpoint \"\u003e\nrootly.WebhooksEndpoint \u003c/span\u003ecan be imported using the \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e command.\n\n```sh\n$ pulumi import rootly:index/webhooksEndpoint:WebhooksEndpoint primary a816421c-6ceb-481a-87c4-585e47451f24\n```\n\nOr using an \u003cspan pulumi-lang-nodejs=\"`import`\" pulumi-lang-dotnet=\"`Import`\" pulumi-lang-go=\"`import`\" pulumi-lang-python=\"`import`\" pulumi-lang-yaml=\"`import`\" pulumi-lang-java=\"`import`\"\u003e`import`\u003c/span\u003e block.\n\n\nLocate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.\n\nHCL can be generated from the import block using the `-generate-config-out` flag.\n\n```sh\npulumi preview -generate-config-out=generated.tf\n```\n\n",
             "properties": {
                 "enabled": {
                     "type": "boolean"
@@ -19940,7 +20124,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.\n"
+                    "description": "Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.\n"
                 },
                 "name": {
                     "type": "string",
@@ -19974,7 +20158,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.\n"
+                    "description": "Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.\n"
                 },
                 "name": {
                     "type": "string",
@@ -20007,7 +20191,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.\n"
+                        "description": "Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.\n"
                     },
                     "name": {
                         "type": "string",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -8,7 +8,7 @@ replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraf
 
 require (
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.128.0
-	github.com/rootlyhq/terraform-provider-rootly/v2 v2.28.1-0.20260504164409-ec0a7eab2614
+	github.com/rootlyhq/terraform-provider-rootly/v5 v5.15.0
 )
 
 require (
@@ -78,14 +78,14 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
-	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
+	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/djherbis/times v1.6.0 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
-	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/color v1.19.0 // indirect
@@ -197,7 +197,7 @@ require (
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
-	github.com/spf13/afero v1.11.0 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
@@ -220,7 +220,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.54.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.54.0 // indirect
-	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.42.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
@@ -251,8 +251,8 @@ require (
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect
+	google.golang.org/grpc v1.81.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2970,8 +2970,9 @@ github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3/go.mod h1:W+zGtBO5Y1Ig
 github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
-github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
+github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
+github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -3032,8 +3033,9 @@ github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9
 github.com/envoyproxy/go-control-plane/envoy v1.32.2/go.mod h1:eR2SOX2IedqlPvmiKjUH7Wu//S602JKI7HPC/L3SRq8=
 github.com/envoyproxy/go-control-plane/envoy v1.32.3/go.mod h1:F6hWupPfh75TBXGKA++MCT/CZHFq5r9/uwt/kQYkZfE=
 github.com/envoyproxy/go-control-plane/envoy v1.32.4/go.mod h1:Gzjc5k8JcJswLjAx1Zm+wSYE20UrLtt7JZMWiWQXQEw=
-github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
 github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
+github.com/envoyproxy/go-control-plane/envoy v1.37.0 h1:u3riX6BoYRfF4Dr7dwSOroNfdSbEPe9Yyl09/B6wBrQ=
+github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an9lx6VBE2cnb8wp1vEGNYGI=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
@@ -3046,8 +3048,9 @@ github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7
 github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
 github.com/envoyproxy/protoc-gen-validate v1.1.0/go.mod h1:sXRDRVmzEbkM7CVcM06s9shE/m23dg3wzjl0UWqJ2q4=
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
-github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
+github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
+github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/esiqveland/notify v0.11.0/go.mod h1:63UbVSaeJwF0LVJARHFuPgUAoM7o1BEvCZyknsuonBc=
@@ -3907,8 +3910,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rootlyhq/terraform-provider-rootly/v2 v2.28.1-0.20260504164409-ec0a7eab2614 h1:Ynqxhdd8aRQ/wSCDNSwnAwYZtu2OxdBwetkH1q1PEy8=
-github.com/rootlyhq/terraform-provider-rootly/v2 v2.28.1-0.20260504164409-ec0a7eab2614/go.mod h1:PNluk2U70yGVQCFugOxBAob1ujQdnRTQpVqGLC4O2Qc=
+github.com/rootlyhq/terraform-provider-rootly/v5 v5.15.0 h1:yEr/+j6RlzZJE5t+AH5HeCZ5J7GJaUhcR8/vv36HOIs=
+github.com/rootlyhq/terraform-provider-rootly/v5 v5.15.0/go.mod h1:xXuTA0Spz+WNrSKRj6uwez7FMhkbA0jVnyKwS6qoE8g=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.21.0/go.mod h1:ZPhntP/xmq1nnND05hhpAh2QMhSsA4UN3MGZ6O2J3hM=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -3956,8 +3959,8 @@ github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY52
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/afero v1.10.0/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
-github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
-github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
+github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
+github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
@@ -4108,8 +4111,9 @@ go.opentelemetry.io/contrib/detectors/gcp v1.33.0/go.mod h1:ZHrLmr4ikK2AwRj9QL+c
 go.opentelemetry.io/contrib/detectors/gcp v1.34.0/go.mod h1:cV4BMFcscUR/ckqLkbfQmF0PRsq8w/lMGzdbCSveBHo=
 go.opentelemetry.io/contrib/detectors/gcp v1.35.0/go.mod h1:qGWP8/+ILwMRIUf9uIVLloR1uo5ZYAslM4O6OqUi1DA=
 go.opentelemetry.io/contrib/detectors/gcp v1.36.0/go.mod h1:IbBN8uAIIx734PTonTPxAxnjc2pQTxWNkwfstZ+6H2k=
-go.opentelemetry.io/contrib/detectors/gcp v1.39.0 h1:kWRNZMsfBHZ+uHjiH4y7Etn2FK26LAGkNFw7RHv1DhE=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0/go.mod h1:t/OGqzHBa5v6RHZwrDBJ2OirWc+4q/w2fTbLZwAKjTk=
+go.opentelemetry.io/contrib/detectors/gcp v1.42.0 h1:kpt2PEJuOuqYkPcktfJqWWDjTEd/FNgrxcniL7kQrXQ=
+go.opentelemetry.io/contrib/detectors/gcp v1.42.0/go.mod h1:W9zQ439utxymRrXsUOzZbFX4JhLxXU4+ZnCt8GG7yA8=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1/go.mod h1:4UoMYEZOC0yN/sPGH76KPkkU7zgiEWYWL9vwmbnTJPE=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0/go.mod h1:r9vWsPS/3AQItv3OSlEJ/E4mbrhUbbw18meOjArPtKQ=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.48.0/go.mod h1:tIKj3DbO8N9Y2xo52og3irLsPI4GW02DSMtrVgNMgxg=
@@ -5567,8 +5571,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20250721164621-a45f3dfb1074/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250728155136-f173205681a0/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251124214823-79d6a2a48846/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 h1:tEkOQcXgF6dH1G+MVKZrfpYvozGrzb91k6ha7jireSM=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 h1:pfIbyB44sWzHiCpRqIen67ZQnVXSfIxWrqUMk1qwODE=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -5653,8 +5657,8 @@ google.golang.org/grpc v1.74.2/go.mod h1:CtQ+BGjaAIXHs/5YS3i473GqwBBa1zGQNevxdeB
 google.golang.org/grpc v1.75.0/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
 google.golang.org/grpc v1.75.1/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
 google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
-google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
-google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc v1.81.0 h1:W3G9N3KQf3BU+YuCtGKJk0CmxQNbAISICD/9AORxLIw=
+google.golang.org/grpc v1.81.0/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0/go.mod h1:Dk1tviKTvMCz5tvh7t+fh94dhmQVHuCt2OzJB3CTW9Y=
 google.golang.org/grpc/examples v0.0.0-20201112215255-90f1b3ee835b/go.mod h1:IBqQ7wSUJ2Ep09a8rMWFsg4fmI2r38zwsq8a0GgxXpM=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -26,7 +26,7 @@ import (
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 
 	// Replace this provider with the provider you are bridging.
-	rootly "github.com/rootlyhq/terraform-provider-rootly/v2/provider"
+	rootly "github.com/rootlyhq/terraform-provider-rootly/v5/provider"
 
 	"github.com/rootlyhq/pulumi-rootly/provider/pkg/version"
 )
@@ -138,7 +138,7 @@ func Provider() tfbridge.ProviderInfo {
 		// The GitHub Org for the provider - defaults to `terraform-providers`. Note that this should
 		// match the TF provider module's require directive, not any replace directives.
 		GitHubOrg:               "rootlyhq",
-		TFProviderModuleVersion: "v2",
+		TFProviderModuleVersion: "v5",
 		MetadataInfo:            tfbridge.NewProviderMetadata(metadata),
 		Config:                  map[string]*tfbridge.SchemaInfo{
 			// Add any required configuration here, or remove the example below if

--- a/sdk/go/rootly/alertField.go
+++ b/sdk/go/rootly/alertField.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // AlertField can be imported using the `import` command.

--- a/sdk/go/rootly/alertRoutingRule.go
+++ b/sdk/go/rootly/alertRoutingRule.go
@@ -14,6 +14,8 @@ import (
 
 // *Note: If you are an advanced alert routing user, you should use the Alert Routes resource/data source instead of this one. If you don't know whether you are an advanced alert routing user, please contact Rootly customer support.*
 //
+// ## Example Usage
+//
 // ## Import
 //
 // AlertRoutingRule can be imported using the `import` command.

--- a/sdk/go/rootly/alertUrgency.go
+++ b/sdk/go/rootly/alertUrgency.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // AlertUrgency can be imported using the `import` command.

--- a/sdk/go/rootly/alertsSource.go
+++ b/sdk/go/rootly/alertsSource.go
@@ -70,7 +70,7 @@ type AlertsSource struct {
 	ResolutionRuleAttributes AlertsSourceResolutionRuleAttributesOutput `pulumi:"resolutionRuleAttributes"`
 	// The secret used to authenticate non-email alert sources
 	Secret pulumi.StringOutput `pulumi:"secret"`
-	// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
+	// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `dynatrace`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `awsSns`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
 	SourceType pulumi.StringPtrOutput `pulumi:"sourceType"`
 	// Provide additional attributes for generic*webhook alerts source
 	SourceableAttributes AlertsSourceSourceableAttributesOutput `pulumi:"sourceableAttributes"`
@@ -143,7 +143,7 @@ type alertsSourceState struct {
 	ResolutionRuleAttributes *AlertsSourceResolutionRuleAttributes `pulumi:"resolutionRuleAttributes"`
 	// The secret used to authenticate non-email alert sources
 	Secret *string `pulumi:"secret"`
-	// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
+	// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `dynatrace`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `awsSns`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
 	SourceType *string `pulumi:"sourceType"`
 	// Provide additional attributes for generic*webhook alerts source
 	SourceableAttributes *AlertsSourceSourceableAttributes `pulumi:"sourceableAttributes"`
@@ -180,7 +180,7 @@ type AlertsSourceState struct {
 	ResolutionRuleAttributes AlertsSourceResolutionRuleAttributesPtrInput
 	// The secret used to authenticate non-email alert sources
 	Secret pulumi.StringPtrInput
-	// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
+	// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `dynatrace`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `awsSns`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
 	SourceType pulumi.StringPtrInput
 	// Provide additional attributes for generic*webhook alerts source
 	SourceableAttributes AlertsSourceSourceableAttributesPtrInput
@@ -221,7 +221,7 @@ type alertsSourceArgs struct {
 	ResolutionRuleAttributes *AlertsSourceResolutionRuleAttributes `pulumi:"resolutionRuleAttributes"`
 	// The secret used to authenticate non-email alert sources
 	Secret *string `pulumi:"secret"`
-	// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
+	// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `dynatrace`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `awsSns`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
 	SourceType *string `pulumi:"sourceType"`
 	// Provide additional attributes for generic*webhook alerts source
 	SourceableAttributes *AlertsSourceSourceableAttributes `pulumi:"sourceableAttributes"`
@@ -259,7 +259,7 @@ type AlertsSourceArgs struct {
 	ResolutionRuleAttributes AlertsSourceResolutionRuleAttributesPtrInput
 	// The secret used to authenticate non-email alert sources
 	Secret pulumi.StringPtrInput
-	// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
+	// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `dynatrace`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `awsSns`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
 	SourceType pulumi.StringPtrInput
 	// Provide additional attributes for generic*webhook alerts source
 	SourceableAttributes AlertsSourceSourceableAttributesPtrInput
@@ -425,7 +425,7 @@ func (o AlertsSourceOutput) Secret() pulumi.StringOutput {
 	return o.ApplyT(func(v *AlertsSource) pulumi.StringOutput { return v.Secret }).(pulumi.StringOutput)
 }
 
-// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
+// The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `dynatrace`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `awsSns`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
 func (o AlertsSourceOutput) SourceType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *AlertsSource) pulumi.StringPtrOutput { return v.SourceType }).(pulumi.StringPtrOutput)
 }

--- a/sdk/go/rootly/apiKey.go
+++ b/sdk/go/rootly/apiKey.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // ApiKey can be imported using the `import` command.

--- a/sdk/go/rootly/catalog.go
+++ b/sdk/go/rootly/catalog.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // Catalog can be imported using the `import` command.

--- a/sdk/go/rootly/catalogChecklistTemplate.go
+++ b/sdk/go/rootly/catalogChecklistTemplate.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // CatalogChecklistTemplate can be imported using the `import` command.

--- a/sdk/go/rootly/catalogEntity.go
+++ b/sdk/go/rootly/catalogEntity.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // CatalogEntity can be imported using the `import` command.

--- a/sdk/go/rootly/catalogProperty.go
+++ b/sdk/go/rootly/catalogProperty.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // CatalogProperty can be imported using the `import` command.

--- a/sdk/go/rootly/cause.go
+++ b/sdk/go/rootly/cause.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // Cause can be imported using the `import` command.

--- a/sdk/go/rootly/communicationsGroup.go
+++ b/sdk/go/rootly/communicationsGroup.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // CommunicationsGroup can be imported using the `import` command.

--- a/sdk/go/rootly/communicationsStage.go
+++ b/sdk/go/rootly/communicationsStage.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // CommunicationsStage can be imported using the `import` command.

--- a/sdk/go/rootly/communicationsTemplate.go
+++ b/sdk/go/rootly/communicationsTemplate.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // CommunicationsTemplate can be imported using the `import` command.

--- a/sdk/go/rootly/communicationsType.go
+++ b/sdk/go/rootly/communicationsType.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // CommunicationsType can be imported using the `import` command.

--- a/sdk/go/rootly/customField.go
+++ b/sdk/go/rootly/customField.go
@@ -14,6 +14,8 @@ import (
 
 // DEPRECATED: Please use `FormField` resource instead.
 //
+// ## Example Usage
+//
 // ## Import
 //
 // CustomField can be imported using the `import` command.

--- a/sdk/go/rootly/customFieldOption.go
+++ b/sdk/go/rootly/customFieldOption.go
@@ -14,6 +14,8 @@ import (
 
 // DEPRECATED: Please use `FormField` and `FormFieldOption` resources instead.
 //
+// ## Example Usage
+//
 // ## Import
 //
 // CustomFieldOption can be imported using the `import` command.

--- a/sdk/go/rootly/edgeConnector.go
+++ b/sdk/go/rootly/edgeConnector.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // EdgeConnector can be imported using the `import` command.

--- a/sdk/go/rootly/heartbeat.go
+++ b/sdk/go/rootly/heartbeat.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // Heartbeat can be imported using the `import` command.

--- a/sdk/go/rootly/incidentRole.go
+++ b/sdk/go/rootly/incidentRole.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // IncidentRole can be imported using the `import` command.

--- a/sdk/go/rootly/incidentRoleTask.go
+++ b/sdk/go/rootly/incidentRoleTask.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // IncidentRoleTask can be imported using the `import` command.

--- a/sdk/go/rootly/incidentSubStatus.go
+++ b/sdk/go/rootly/incidentSubStatus.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // IncidentSubStatus can be imported using the `import` command.

--- a/sdk/go/rootly/incidentType.go
+++ b/sdk/go/rootly/incidentType.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // IncidentType can be imported using the `import` command.

--- a/sdk/go/rootly/onCallRole.go
+++ b/sdk/go/rootly/onCallRole.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // OnCallRole can be imported using the `import` command.
@@ -19,9 +21,15 @@ import (
 // $ pulumi import rootly:index/onCallRole:OnCallRole primary a816421c-6ceb-481a-87c4-585e47451f24
 // ```
 //
+// You can also import by slug:
+//
+// ```sh
+// $ pulumi import rootly:index/onCallRole:OnCallRole primary my-oncall-role-slug
+// ```
+//
 // Or using an `import` block.
 //
-// Locate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.
+// Locate the resource id by listing on-call roles through the API (`GET /v1/on_call_roles`), as role IDs are not visible in the web app.
 //
 // HCL can be generated from the import block using the `-generate-config-out` flag.
 //

--- a/sdk/go/rootly/onCallShadow.go
+++ b/sdk/go/rootly/onCallShadow.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // OnCallShadow can be imported using the `import` command.

--- a/sdk/go/rootly/playbook.go
+++ b/sdk/go/rootly/playbook.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // Playbook can be imported using the `import` command.

--- a/sdk/go/rootly/playbookTask.go
+++ b/sdk/go/rootly/playbookTask.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // PlaybookTask can be imported using the `import` command.

--- a/sdk/go/rootly/postMortemTemplate.go
+++ b/sdk/go/rootly/postMortemTemplate.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // PostMortemTemplate can be imported using the `import` command.

--- a/sdk/go/rootly/pulumiTypes.go
+++ b/sdk/go/rootly/pulumiTypes.go
@@ -9359,15 +9359,15 @@ func (o TeamSlackChannelArrayOutput) Index(i pulumi.IntInput) TeamSlackChannelOu
 }
 
 type WorkflowActionItemTriggerParams struct {
-	// Value must be one off `ALL`, `ANY`, `NONE`.
+	// Value must be one of `ALL`, `ANY`, `NONE`.
 	IncidentActionItemCondition *string `pulumi:"incidentActionItemCondition"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentActionItemConditionGroup *string `pulumi:"incidentActionItemConditionGroup"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentActionItemConditionKind *string `pulumi:"incidentActionItemConditionKind"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentActionItemConditionPriority *string `pulumi:"incidentActionItemConditionPriority"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentActionItemConditionStatus *string  `pulumi:"incidentActionItemConditionStatus"`
 	IncidentActionItemGroupIds        []string `pulumi:"incidentActionItemGroupIds"`
 	// Value must be one of `task`, `followUp`.
@@ -9376,36 +9376,43 @@ type WorkflowActionItemTriggerParams struct {
 	IncidentActionItemPriorities []string `pulumi:"incidentActionItemPriorities"`
 	// Value must be one of `open`, `inProgress`, `cancelled`, `done`.
 	IncidentActionItemStatuses []string `pulumi:"incidentActionItemStatuses"`
-	// Value must be one off `ALL`, `ANY`, `NONE`.
-	IncidentCondition               *string `pulumi:"incidentCondition"`
+	// Value must be one of `ALL`, `ANY`, `NONE`.
+	IncidentCondition *string `pulumi:"incidentCondition"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionAcknowledgedAt *string `pulumi:"incidentConditionAcknowledgedAt"`
-	IncidentConditionDetectedAt     *string `pulumi:"incidentConditionDetectedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionDetectedAt *string `pulumi:"incidentConditionDetectedAt"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionEnvironment *string `pulumi:"incidentConditionEnvironment"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionFunctionality *string `pulumi:"incidentConditionFunctionality"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionGroup *string `pulumi:"incidentConditionGroup"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentRoles *string `pulumi:"incidentConditionIncidentRoles"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentType *string `pulumi:"incidentConditionIncidentType"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionKind        *string `pulumi:"incidentConditionKind"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionKind *string `pulumi:"incidentConditionKind"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionMitigatedAt *string `pulumi:"incidentConditionMitigatedAt"`
-	IncidentConditionResolvedAt  *string `pulumi:"incidentConditionResolvedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionResolvedAt *string `pulumi:"incidentConditionResolvedAt"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionService *string `pulumi:"incidentConditionService"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionSeverity  *string `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionSeverity *string `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionStartedAt *string `pulumi:"incidentConditionStartedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionStatus *string `pulumi:"incidentConditionStatus"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionSubStatus *string `pulumi:"incidentConditionSubStatus"`
-	IncidentConditionSummary   *string `pulumi:"incidentConditionSummary"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionVisibility   *string `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionSummary *string `pulumi:"incidentConditionSummary"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionVisibility *string `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `IS`.
 	IncidentConditionalInactivity *string `pulumi:"incidentConditionalInactivity"`
 	// ex. 10 min, 1h, 3 days, 2 weeks
 	IncidentInactivityDuration *string `pulumi:"incidentInactivityDuration"`
@@ -9414,7 +9421,7 @@ type WorkflowActionItemTriggerParams struct {
 	// Value must be one of `inTriage`, `started`, `detected`, `acknowledged`, `mitigated`, `resolved`, `closed`, `cancelled`, `scheduled`, `inProgress`, `completed`.
 	IncidentStatuses     []string `pulumi:"incidentStatuses"`
 	IncidentVisibilities []string `pulumi:"incidentVisibilities"`
-	// Value must be one off `actionItem`.
+	// Value must be one of `actionItem`.
 	TriggerType *string `pulumi:"triggerType"`
 	// Actions that trigger the workflow. One of custom*fields.\n\n.updated, incident*updated, action*item*created, action*item*updated, assigned*user*updated, summary*updated, description*updated, status*updated, priority*updated, due*date*updated, teams*updated, slack*command
 	Triggers []string `pulumi:"triggers"`
@@ -9432,15 +9439,15 @@ type WorkflowActionItemTriggerParamsInput interface {
 }
 
 type WorkflowActionItemTriggerParamsArgs struct {
-	// Value must be one off `ALL`, `ANY`, `NONE`.
+	// Value must be one of `ALL`, `ANY`, `NONE`.
 	IncidentActionItemCondition pulumi.StringPtrInput `pulumi:"incidentActionItemCondition"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentActionItemConditionGroup pulumi.StringPtrInput `pulumi:"incidentActionItemConditionGroup"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentActionItemConditionKind pulumi.StringPtrInput `pulumi:"incidentActionItemConditionKind"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentActionItemConditionPriority pulumi.StringPtrInput `pulumi:"incidentActionItemConditionPriority"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentActionItemConditionStatus pulumi.StringPtrInput   `pulumi:"incidentActionItemConditionStatus"`
 	IncidentActionItemGroupIds        pulumi.StringArrayInput `pulumi:"incidentActionItemGroupIds"`
 	// Value must be one of `task`, `followUp`.
@@ -9449,36 +9456,43 @@ type WorkflowActionItemTriggerParamsArgs struct {
 	IncidentActionItemPriorities pulumi.StringArrayInput `pulumi:"incidentActionItemPriorities"`
 	// Value must be one of `open`, `inProgress`, `cancelled`, `done`.
 	IncidentActionItemStatuses pulumi.StringArrayInput `pulumi:"incidentActionItemStatuses"`
-	// Value must be one off `ALL`, `ANY`, `NONE`.
-	IncidentCondition               pulumi.StringPtrInput `pulumi:"incidentCondition"`
+	// Value must be one of `ALL`, `ANY`, `NONE`.
+	IncidentCondition pulumi.StringPtrInput `pulumi:"incidentCondition"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionAcknowledgedAt pulumi.StringPtrInput `pulumi:"incidentConditionAcknowledgedAt"`
-	IncidentConditionDetectedAt     pulumi.StringPtrInput `pulumi:"incidentConditionDetectedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionDetectedAt pulumi.StringPtrInput `pulumi:"incidentConditionDetectedAt"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionEnvironment pulumi.StringPtrInput `pulumi:"incidentConditionEnvironment"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionFunctionality pulumi.StringPtrInput `pulumi:"incidentConditionFunctionality"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionGroup pulumi.StringPtrInput `pulumi:"incidentConditionGroup"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentRoles pulumi.StringPtrInput `pulumi:"incidentConditionIncidentRoles"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentType pulumi.StringPtrInput `pulumi:"incidentConditionIncidentType"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionKind        pulumi.StringPtrInput `pulumi:"incidentConditionKind"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionKind pulumi.StringPtrInput `pulumi:"incidentConditionKind"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionMitigatedAt pulumi.StringPtrInput `pulumi:"incidentConditionMitigatedAt"`
-	IncidentConditionResolvedAt  pulumi.StringPtrInput `pulumi:"incidentConditionResolvedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionResolvedAt pulumi.StringPtrInput `pulumi:"incidentConditionResolvedAt"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionService pulumi.StringPtrInput `pulumi:"incidentConditionService"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionSeverity  pulumi.StringPtrInput `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionSeverity pulumi.StringPtrInput `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionStartedAt pulumi.StringPtrInput `pulumi:"incidentConditionStartedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionStatus pulumi.StringPtrInput `pulumi:"incidentConditionStatus"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionSubStatus pulumi.StringPtrInput `pulumi:"incidentConditionSubStatus"`
-	IncidentConditionSummary   pulumi.StringPtrInput `pulumi:"incidentConditionSummary"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionVisibility   pulumi.StringPtrInput `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionSummary pulumi.StringPtrInput `pulumi:"incidentConditionSummary"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionVisibility pulumi.StringPtrInput `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `IS`.
 	IncidentConditionalInactivity pulumi.StringPtrInput `pulumi:"incidentConditionalInactivity"`
 	// ex. 10 min, 1h, 3 days, 2 weeks
 	IncidentInactivityDuration pulumi.StringPtrInput `pulumi:"incidentInactivityDuration"`
@@ -9487,7 +9501,7 @@ type WorkflowActionItemTriggerParamsArgs struct {
 	// Value must be one of `inTriage`, `started`, `detected`, `acknowledged`, `mitigated`, `resolved`, `closed`, `cancelled`, `scheduled`, `inProgress`, `completed`.
 	IncidentStatuses     pulumi.StringArrayInput `pulumi:"incidentStatuses"`
 	IncidentVisibilities pulumi.StringArrayInput `pulumi:"incidentVisibilities"`
-	// Value must be one off `actionItem`.
+	// Value must be one of `actionItem`.
 	TriggerType pulumi.StringPtrInput `pulumi:"triggerType"`
 	// Actions that trigger the workflow. One of custom*fields.\n\n.updated, incident*updated, action*item*created, action*item*updated, assigned*user*updated, summary*updated, description*updated, status*updated, priority*updated, due*date*updated, teams*updated, slack*command
 	Triggers pulumi.StringArrayInput `pulumi:"triggers"`
@@ -9570,27 +9584,27 @@ func (o WorkflowActionItemTriggerParamsOutput) ToWorkflowActionItemTriggerParams
 	}).(WorkflowActionItemTriggerParamsPtrOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentActionItemCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentActionItemCondition }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentActionItemConditionGroup() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentActionItemConditionGroup }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentActionItemConditionKind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentActionItemConditionKind }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentActionItemConditionPriority() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentActionItemConditionPriority }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentActionItemConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentActionItemConditionStatus }).(pulumi.StringPtrOutput)
 }
@@ -9614,90 +9628,97 @@ func (o WorkflowActionItemTriggerParamsOutput) IncidentActionItemStatuses() pulu
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) []string { return v.IncidentActionItemStatuses }).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentCondition }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionAcknowledgedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionAcknowledgedAt }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionDetectedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionDetectedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionEnvironment() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionEnvironment }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionFunctionality() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionFunctionality }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionGroup() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionGroup }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionIncidentRoles() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionIncidentRoles }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionIncidentType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionIncidentType }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionKind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionKind }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionMitigatedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionMitigatedAt }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionResolvedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionResolvedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionService() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionService }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionSeverity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionSeverity }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionStartedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionStartedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionStatus }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionSubStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionSubStatus }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionSummary() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionSummary }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionVisibility() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionVisibility }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `IS`.
 func (o WorkflowActionItemTriggerParamsOutput) IncidentConditionalInactivity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.IncidentConditionalInactivity }).(pulumi.StringPtrOutput)
 }
@@ -9721,7 +9742,7 @@ func (o WorkflowActionItemTriggerParamsOutput) IncidentVisibilities() pulumi.Str
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) []string { return v.IncidentVisibilities }).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `actionItem`.
+// Value must be one of `actionItem`.
 func (o WorkflowActionItemTriggerParamsOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowActionItemTriggerParams) *string { return v.TriggerType }).(pulumi.StringPtrOutput)
 }
@@ -9755,7 +9776,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) Elem() WorkflowActionItemTrigg
 	}).(WorkflowActionItemTriggerParamsOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentActionItemCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9765,7 +9786,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentActionItemCondition() 
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentActionItemConditionGroup() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9775,7 +9796,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentActionItemConditionGro
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentActionItemConditionKind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9785,7 +9806,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentActionItemConditionKin
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentActionItemConditionPriority() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9795,7 +9816,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentActionItemConditionPri
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentActionItemConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9844,7 +9865,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentActionItemStatuses() p
 	}).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9854,6 +9875,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentCondition() pulumi.Str
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionAcknowledgedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9863,6 +9885,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionAcknowledgedA
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionDetectedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9872,7 +9895,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionDetectedAt() 
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionEnvironment() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9882,7 +9905,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionEnvironment()
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionFunctionality() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9892,7 +9915,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionFunctionality
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionGroup() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9902,7 +9925,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionGroup() pulum
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionIncidentRoles() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9912,7 +9935,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionIncidentRoles
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionIncidentType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9922,7 +9945,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionIncidentType(
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionKind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9932,6 +9955,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionKind() pulumi
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionMitigatedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9941,6 +9965,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionMitigatedAt()
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionResolvedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9950,7 +9975,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionResolvedAt() 
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionService() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9960,7 +9985,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionService() pul
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionSeverity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9970,6 +9995,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionSeverity() pu
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionStartedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9979,7 +10005,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionStartedAt() p
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9989,7 +10015,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionStatus() pulu
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionSubStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -9999,6 +10025,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionSubStatus() p
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionSummary() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -10008,7 +10035,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionSummary() pul
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionVisibility() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -10018,6 +10045,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionVisibility() 
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `IS`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentConditionalInactivity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -10066,7 +10094,7 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) IncidentVisibilities() pulumi.
 	}).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `actionItem`.
+// Value must be one of `actionItem`.
 func (o WorkflowActionItemTriggerParamsPtrOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowActionItemTriggerParams) *string {
 		if v == nil {
@@ -10087,25 +10115,25 @@ func (o WorkflowActionItemTriggerParamsPtrOutput) Triggers() pulumi.StringArrayO
 }
 
 type WorkflowAlertTriggerParams struct {
-	// Value must be one off `ALL`, `ANY`, `NONE`.
+	// Value must be one of `ALL`, `ANY`, `NONE`.
 	AlertCondition *string `pulumi:"alertCondition"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	AlertConditionLabel *string `pulumi:"alertConditionLabel"`
 	// Value must be one of true or false
 	AlertConditionLabelUseRegexp *bool `pulumi:"alertConditionLabelUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	AlertConditionPayload *string `pulumi:"alertConditionPayload"`
 	// Value must be one of true or false
 	AlertConditionPayloadUseRegexp *bool `pulumi:"alertConditionPayloadUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	AlertConditionSource *string `pulumi:"alertConditionSource"`
 	// Value must be one of true or false
 	AlertConditionSourceUseRegexp *bool `pulumi:"alertConditionSourceUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	AlertConditionStatus *string `pulumi:"alertConditionStatus"`
 	// Value must be one of true or false
 	AlertConditionStatusUseRegexp *bool `pulumi:"alertConditionStatusUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	AlertConditionUrgency  *string                                           `pulumi:"alertConditionUrgency"`
 	AlertFieldConditions   []WorkflowAlertTriggerParamsAlertFieldCondition   `pulumi:"alertFieldConditions"`
 	AlertLabels            []string                                          `pulumi:"alertLabels"`
@@ -10116,7 +10144,7 @@ type WorkflowAlertTriggerParams struct {
 	AlertSources      []string `pulumi:"alertSources"`
 	AlertStatuses     []string `pulumi:"alertStatuses"`
 	AlertUrgencyIds   []string `pulumi:"alertUrgencyIds"`
-	// Value must be one off `alert`.
+	// Value must be one of `alert`.
 	TriggerType *string `pulumi:"triggerType"`
 	// Actions that trigger the workflow. Value must be one of `alertCreated`, `alertStatusUpdated`.
 	Triggers []string `pulumi:"triggers"`
@@ -10134,25 +10162,25 @@ type WorkflowAlertTriggerParamsInput interface {
 }
 
 type WorkflowAlertTriggerParamsArgs struct {
-	// Value must be one off `ALL`, `ANY`, `NONE`.
+	// Value must be one of `ALL`, `ANY`, `NONE`.
 	AlertCondition pulumi.StringPtrInput `pulumi:"alertCondition"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	AlertConditionLabel pulumi.StringPtrInput `pulumi:"alertConditionLabel"`
 	// Value must be one of true or false
 	AlertConditionLabelUseRegexp pulumi.BoolPtrInput `pulumi:"alertConditionLabelUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	AlertConditionPayload pulumi.StringPtrInput `pulumi:"alertConditionPayload"`
 	// Value must be one of true or false
 	AlertConditionPayloadUseRegexp pulumi.BoolPtrInput `pulumi:"alertConditionPayloadUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	AlertConditionSource pulumi.StringPtrInput `pulumi:"alertConditionSource"`
 	// Value must be one of true or false
 	AlertConditionSourceUseRegexp pulumi.BoolPtrInput `pulumi:"alertConditionSourceUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	AlertConditionStatus pulumi.StringPtrInput `pulumi:"alertConditionStatus"`
 	// Value must be one of true or false
 	AlertConditionStatusUseRegexp pulumi.BoolPtrInput `pulumi:"alertConditionStatusUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	AlertConditionUrgency  pulumi.StringPtrInput                                    `pulumi:"alertConditionUrgency"`
 	AlertFieldConditions   WorkflowAlertTriggerParamsAlertFieldConditionArrayInput  `pulumi:"alertFieldConditions"`
 	AlertLabels            pulumi.StringArrayInput                                  `pulumi:"alertLabels"`
@@ -10163,7 +10191,7 @@ type WorkflowAlertTriggerParamsArgs struct {
 	AlertSources      pulumi.StringArrayInput `pulumi:"alertSources"`
 	AlertStatuses     pulumi.StringArrayInput `pulumi:"alertStatuses"`
 	AlertUrgencyIds   pulumi.StringArrayInput `pulumi:"alertUrgencyIds"`
-	// Value must be one off `alert`.
+	// Value must be one of `alert`.
 	TriggerType pulumi.StringPtrInput `pulumi:"triggerType"`
 	// Actions that trigger the workflow. Value must be one of `alertCreated`, `alertStatusUpdated`.
 	Triggers pulumi.StringArrayInput `pulumi:"triggers"`
@@ -10246,12 +10274,12 @@ func (o WorkflowAlertTriggerParamsOutput) ToWorkflowAlertTriggerParamsPtrOutputW
 	}).(WorkflowAlertTriggerParamsPtrOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowAlertTriggerParamsOutput) AlertCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *string { return v.AlertCondition }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowAlertTriggerParamsOutput) AlertConditionLabel() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *string { return v.AlertConditionLabel }).(pulumi.StringPtrOutput)
 }
@@ -10261,7 +10289,7 @@ func (o WorkflowAlertTriggerParamsOutput) AlertConditionLabelUseRegexp() pulumi.
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *bool { return v.AlertConditionLabelUseRegexp }).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowAlertTriggerParamsOutput) AlertConditionPayload() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *string { return v.AlertConditionPayload }).(pulumi.StringPtrOutput)
 }
@@ -10271,7 +10299,7 @@ func (o WorkflowAlertTriggerParamsOutput) AlertConditionPayloadUseRegexp() pulum
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *bool { return v.AlertConditionPayloadUseRegexp }).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowAlertTriggerParamsOutput) AlertConditionSource() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *string { return v.AlertConditionSource }).(pulumi.StringPtrOutput)
 }
@@ -10281,7 +10309,7 @@ func (o WorkflowAlertTriggerParamsOutput) AlertConditionSourceUseRegexp() pulumi
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *bool { return v.AlertConditionSourceUseRegexp }).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowAlertTriggerParamsOutput) AlertConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *string { return v.AlertConditionStatus }).(pulumi.StringPtrOutput)
 }
@@ -10291,7 +10319,7 @@ func (o WorkflowAlertTriggerParamsOutput) AlertConditionStatusUseRegexp() pulumi
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *bool { return v.AlertConditionStatusUseRegexp }).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowAlertTriggerParamsOutput) AlertConditionUrgency() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *string { return v.AlertConditionUrgency }).(pulumi.StringPtrOutput)
 }
@@ -10333,7 +10361,7 @@ func (o WorkflowAlertTriggerParamsOutput) AlertUrgencyIds() pulumi.StringArrayOu
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) []string { return v.AlertUrgencyIds }).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `alert`.
+// Value must be one of `alert`.
 func (o WorkflowAlertTriggerParamsOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowAlertTriggerParams) *string { return v.TriggerType }).(pulumi.StringPtrOutput)
 }
@@ -10367,7 +10395,7 @@ func (o WorkflowAlertTriggerParamsPtrOutput) Elem() WorkflowAlertTriggerParamsOu
 	}).(WorkflowAlertTriggerParamsOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowAlertTriggerParamsPtrOutput) AlertCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowAlertTriggerParams) *string {
 		if v == nil {
@@ -10377,7 +10405,7 @@ func (o WorkflowAlertTriggerParamsPtrOutput) AlertCondition() pulumi.StringPtrOu
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowAlertTriggerParamsPtrOutput) AlertConditionLabel() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowAlertTriggerParams) *string {
 		if v == nil {
@@ -10397,7 +10425,7 @@ func (o WorkflowAlertTriggerParamsPtrOutput) AlertConditionLabelUseRegexp() pulu
 	}).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowAlertTriggerParamsPtrOutput) AlertConditionPayload() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowAlertTriggerParams) *string {
 		if v == nil {
@@ -10417,7 +10445,7 @@ func (o WorkflowAlertTriggerParamsPtrOutput) AlertConditionPayloadUseRegexp() pu
 	}).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowAlertTriggerParamsPtrOutput) AlertConditionSource() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowAlertTriggerParams) *string {
 		if v == nil {
@@ -10437,7 +10465,7 @@ func (o WorkflowAlertTriggerParamsPtrOutput) AlertConditionSourceUseRegexp() pul
 	}).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowAlertTriggerParamsPtrOutput) AlertConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowAlertTriggerParams) *string {
 		if v == nil {
@@ -10457,7 +10485,7 @@ func (o WorkflowAlertTriggerParamsPtrOutput) AlertConditionStatusUseRegexp() pul
 	}).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowAlertTriggerParamsPtrOutput) AlertConditionUrgency() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowAlertTriggerParams) *string {
 		if v == nil {
@@ -10540,7 +10568,7 @@ func (o WorkflowAlertTriggerParamsPtrOutput) AlertUrgencyIds() pulumi.StringArra
 	}).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `alert`.
+// Value must be one of `alert`.
 func (o WorkflowAlertTriggerParamsPtrOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowAlertTriggerParams) *string {
 		if v == nil {
@@ -10933,49 +10961,56 @@ func (o WorkflowAlertTriggerParamsAlertPayloadConditionsConditionArrayOutput) In
 }
 
 type WorkflowIncidentTriggerParams struct {
-	// Value must be one off `ALL`, `ANY`, `NONE`.
-	IncidentCondition               *string `pulumi:"incidentCondition"`
+	// Value must be one of `ALL`, `ANY`, `NONE`.
+	IncidentCondition *string `pulumi:"incidentCondition"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionAcknowledgedAt *string `pulumi:"incidentConditionAcknowledgedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionCause      *string `pulumi:"incidentConditionCause"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionCause *string `pulumi:"incidentConditionCause"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionDetectedAt *string `pulumi:"incidentConditionDetectedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionEnvironment *string `pulumi:"incidentConditionEnvironment"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionFunctionality *string `pulumi:"incidentConditionFunctionality"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionGroup *string `pulumi:"incidentConditionGroup"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentRoles *string `pulumi:"incidentConditionIncidentRoles"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentType *string `pulumi:"incidentConditionIncidentType"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionKind        *string `pulumi:"incidentConditionKind"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionKind *string `pulumi:"incidentConditionKind"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionMitigatedAt *string `pulumi:"incidentConditionMitigatedAt"`
-	IncidentConditionResolvedAt  *string `pulumi:"incidentConditionResolvedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionResolvedAt *string `pulumi:"incidentConditionResolvedAt"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionService *string `pulumi:"incidentConditionService"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionSeverity  *string `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionSeverity *string `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionStartedAt *string `pulumi:"incidentConditionStartedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionStatus *string `pulumi:"incidentConditionStatus"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionSubStatus *string `pulumi:"incidentConditionSubStatus"`
-	IncidentConditionSummary   *string `pulumi:"incidentConditionSummary"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionVisibility   *string `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionSummary *string `pulumi:"incidentConditionSummary"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionVisibility *string `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `IS`.
 	IncidentConditionalInactivity *string `pulumi:"incidentConditionalInactivity"`
 	// ex. 10 min, 1h, 3 days, 2 weeks
 	IncidentInactivityDuration *string `pulumi:"incidentInactivityDuration"`
 	// Value must be one of `test`, `testSub`, `example`, `exampleSub`, `normal`, `normalSub`, `backfilled`, `scheduled`, `scheduledSub`.
 	IncidentKinds []string `pulumi:"incidentKinds"`
-	// [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentPostMortemConditionCause *string `pulumi:"incidentPostMortemConditionCause"`
 	// Value must be one of `inTriage`, `started`, `detected`, `acknowledged`, `mitigated`, `resolved`, `closed`, `cancelled`, `scheduled`, `inProgress`, `completed`.
 	IncidentStatuses     []string `pulumi:"incidentStatuses"`
 	IncidentVisibilities []string `pulumi:"incidentVisibilities"`
-	// Value must be one off `incident`.
+	// Value must be one of `incident`.
 	TriggerType *string `pulumi:"triggerType"`
 	// Actions that trigger the workflow. One of custom*fields.\n\n.updated, incident*in*triage, incident*created, incident*started, incident*updated, title*updated, summary*updated, status*updated, severity*updated, environments*added, environments*removed, environments*updated, incident*types*added, incident*types*removed, incident*types*updated, services*added, services*removed, services*updated, visibility*updated, functionalities*added, functionalities*removed, functionalities*updated, teams*added, teams*removed, teams*updated, causes*added, causes*removed, causes*updated, timeline*updated, status*page*timeline*updated, role*assignments*updated, role*assignments*added, role*assignments*removed, slack*command, slack*channel*created, slack*channel*converted, microsoft*teams*channel*created, microsoft*teams*chat*created, subscribers*updated, subscribers*added, subscribers*removed, user*joined*slack*channel, user*left*slack*channel
 	Triggers []string `pulumi:"triggers"`
@@ -10993,49 +11028,56 @@ type WorkflowIncidentTriggerParamsInput interface {
 }
 
 type WorkflowIncidentTriggerParamsArgs struct {
-	// Value must be one off `ALL`, `ANY`, `NONE`.
-	IncidentCondition               pulumi.StringPtrInput `pulumi:"incidentCondition"`
+	// Value must be one of `ALL`, `ANY`, `NONE`.
+	IncidentCondition pulumi.StringPtrInput `pulumi:"incidentCondition"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionAcknowledgedAt pulumi.StringPtrInput `pulumi:"incidentConditionAcknowledgedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionCause      pulumi.StringPtrInput `pulumi:"incidentConditionCause"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionCause pulumi.StringPtrInput `pulumi:"incidentConditionCause"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionDetectedAt pulumi.StringPtrInput `pulumi:"incidentConditionDetectedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionEnvironment pulumi.StringPtrInput `pulumi:"incidentConditionEnvironment"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionFunctionality pulumi.StringPtrInput `pulumi:"incidentConditionFunctionality"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionGroup pulumi.StringPtrInput `pulumi:"incidentConditionGroup"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentRoles pulumi.StringPtrInput `pulumi:"incidentConditionIncidentRoles"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentType pulumi.StringPtrInput `pulumi:"incidentConditionIncidentType"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionKind        pulumi.StringPtrInput `pulumi:"incidentConditionKind"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionKind pulumi.StringPtrInput `pulumi:"incidentConditionKind"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionMitigatedAt pulumi.StringPtrInput `pulumi:"incidentConditionMitigatedAt"`
-	IncidentConditionResolvedAt  pulumi.StringPtrInput `pulumi:"incidentConditionResolvedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionResolvedAt pulumi.StringPtrInput `pulumi:"incidentConditionResolvedAt"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionService pulumi.StringPtrInput `pulumi:"incidentConditionService"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionSeverity  pulumi.StringPtrInput `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionSeverity pulumi.StringPtrInput `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionStartedAt pulumi.StringPtrInput `pulumi:"incidentConditionStartedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionStatus pulumi.StringPtrInput `pulumi:"incidentConditionStatus"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionSubStatus pulumi.StringPtrInput `pulumi:"incidentConditionSubStatus"`
-	IncidentConditionSummary   pulumi.StringPtrInput `pulumi:"incidentConditionSummary"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionVisibility   pulumi.StringPtrInput `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionSummary pulumi.StringPtrInput `pulumi:"incidentConditionSummary"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionVisibility pulumi.StringPtrInput `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `IS`.
 	IncidentConditionalInactivity pulumi.StringPtrInput `pulumi:"incidentConditionalInactivity"`
 	// ex. 10 min, 1h, 3 days, 2 weeks
 	IncidentInactivityDuration pulumi.StringPtrInput `pulumi:"incidentInactivityDuration"`
 	// Value must be one of `test`, `testSub`, `example`, `exampleSub`, `normal`, `normalSub`, `backfilled`, `scheduled`, `scheduledSub`.
 	IncidentKinds pulumi.StringArrayInput `pulumi:"incidentKinds"`
-	// [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentPostMortemConditionCause pulumi.StringPtrInput `pulumi:"incidentPostMortemConditionCause"`
 	// Value must be one of `inTriage`, `started`, `detected`, `acknowledged`, `mitigated`, `resolved`, `closed`, `cancelled`, `scheduled`, `inProgress`, `completed`.
 	IncidentStatuses     pulumi.StringArrayInput `pulumi:"incidentStatuses"`
 	IncidentVisibilities pulumi.StringArrayInput `pulumi:"incidentVisibilities"`
-	// Value must be one off `incident`.
+	// Value must be one of `incident`.
 	TriggerType pulumi.StringPtrInput `pulumi:"triggerType"`
 	// Actions that trigger the workflow. One of custom*fields.\n\n.updated, incident*in*triage, incident*created, incident*started, incident*updated, title*updated, summary*updated, status*updated, severity*updated, environments*added, environments*removed, environments*updated, incident*types*added, incident*types*removed, incident*types*updated, services*added, services*removed, services*updated, visibility*updated, functionalities*added, functionalities*removed, functionalities*updated, teams*added, teams*removed, teams*updated, causes*added, causes*removed, causes*updated, timeline*updated, status*page*timeline*updated, role*assignments*updated, role*assignments*added, role*assignments*removed, slack*command, slack*channel*created, slack*channel*converted, microsoft*teams*channel*created, microsoft*teams*chat*created, subscribers*updated, subscribers*added, subscribers*removed, user*joined*slack*channel, user*left*slack*channel
 	Triggers pulumi.StringArrayInput `pulumi:"triggers"`
@@ -11118,95 +11160,102 @@ func (o WorkflowIncidentTriggerParamsOutput) ToWorkflowIncidentTriggerParamsPtrO
 	}).(WorkflowIncidentTriggerParamsPtrOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentCondition }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionAcknowledgedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionAcknowledgedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionCause() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionCause }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionDetectedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionDetectedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionEnvironment() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionEnvironment }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionFunctionality() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionFunctionality }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionGroup() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionGroup }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionIncidentRoles() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionIncidentRoles }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionIncidentType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionIncidentType }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionKind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionKind }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionMitigatedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionMitigatedAt }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionResolvedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionResolvedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionService() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionService }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionSeverity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionSeverity }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionStartedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionStartedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionStatus }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionSubStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionSubStatus }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionSummary() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionSummary }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionVisibility() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionVisibility }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `IS`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentConditionalInactivity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentConditionalInactivity }).(pulumi.StringPtrOutput)
 }
@@ -11221,7 +11270,7 @@ func (o WorkflowIncidentTriggerParamsOutput) IncidentKinds() pulumi.StringArrayO
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) []string { return v.IncidentKinds }).(pulumi.StringArrayOutput)
 }
 
-// [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsOutput) IncidentPostMortemConditionCause() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.IncidentPostMortemConditionCause }).(pulumi.StringPtrOutput)
 }
@@ -11235,7 +11284,7 @@ func (o WorkflowIncidentTriggerParamsOutput) IncidentVisibilities() pulumi.Strin
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) []string { return v.IncidentVisibilities }).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `incident`.
+// Value must be one of `incident`.
 func (o WorkflowIncidentTriggerParamsOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowIncidentTriggerParams) *string { return v.TriggerType }).(pulumi.StringPtrOutput)
 }
@@ -11269,7 +11318,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) Elem() WorkflowIncidentTriggerPa
 	}).(WorkflowIncidentTriggerParamsOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11279,6 +11328,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentCondition() pulumi.Strin
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionAcknowledgedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11288,7 +11338,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionAcknowledgedAt(
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionCause() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11298,6 +11348,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionCause() pulumi.
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionDetectedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11307,7 +11358,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionDetectedAt() pu
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionEnvironment() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11317,7 +11368,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionEnvironment() p
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionFunctionality() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11327,7 +11378,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionFunctionality()
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionGroup() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11337,7 +11388,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionGroup() pulumi.
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionIncidentRoles() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11347,7 +11398,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionIncidentRoles()
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionIncidentType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11357,7 +11408,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionIncidentType() 
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionKind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11367,6 +11418,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionKind() pulumi.S
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionMitigatedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11376,6 +11428,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionMitigatedAt() p
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionResolvedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11385,7 +11438,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionResolvedAt() pu
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionService() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11395,7 +11448,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionService() pulum
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionSeverity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11405,6 +11458,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionSeverity() pulu
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionStartedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11414,7 +11468,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionStartedAt() pul
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11424,7 +11478,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionStatus() pulumi
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionSubStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11434,6 +11488,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionSubStatus() pul
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionSummary() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11443,7 +11498,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionSummary() pulum
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionVisibility() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11453,6 +11508,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionVisibility() pu
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `IS`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentConditionalInactivity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11482,7 +11538,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentKinds() pulumi.StringArr
 	}).(pulumi.StringArrayOutput)
 }
 
-// [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentPostMortemConditionCause() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11511,7 +11567,7 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) IncidentVisibilities() pulumi.St
 	}).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `incident`.
+// Value must be one of `incident`.
 func (o WorkflowIncidentTriggerParamsPtrOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowIncidentTriggerParams) *string {
 		if v == nil {
@@ -11532,55 +11588,62 @@ func (o WorkflowIncidentTriggerParamsPtrOutput) Triggers() pulumi.StringArrayOut
 }
 
 type WorkflowPostMortemTriggerParams struct {
-	// Value must be one off `ALL`, `ANY`, `NONE`.
-	IncidentCondition               *string `pulumi:"incidentCondition"`
+	// Value must be one of `ALL`, `ANY`, `NONE`.
+	IncidentCondition *string `pulumi:"incidentCondition"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionAcknowledgedAt *string `pulumi:"incidentConditionAcknowledgedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionCause      *string `pulumi:"incidentConditionCause"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionCause *string `pulumi:"incidentConditionCause"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionDetectedAt *string `pulumi:"incidentConditionDetectedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionEnvironment *string `pulumi:"incidentConditionEnvironment"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionFunctionality *string `pulumi:"incidentConditionFunctionality"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionGroup *string `pulumi:"incidentConditionGroup"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentRoles *string `pulumi:"incidentConditionIncidentRoles"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentType *string `pulumi:"incidentConditionIncidentType"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionKind        *string `pulumi:"incidentConditionKind"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionKind *string `pulumi:"incidentConditionKind"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionMitigatedAt *string `pulumi:"incidentConditionMitigatedAt"`
-	IncidentConditionResolvedAt  *string `pulumi:"incidentConditionResolvedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionResolvedAt *string `pulumi:"incidentConditionResolvedAt"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionService *string `pulumi:"incidentConditionService"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionSeverity  *string `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionSeverity *string `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionStartedAt *string `pulumi:"incidentConditionStartedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionStatus *string `pulumi:"incidentConditionStatus"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionSubStatus *string `pulumi:"incidentConditionSubStatus"`
-	IncidentConditionSummary   *string `pulumi:"incidentConditionSummary"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionVisibility   *string `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionSummary *string `pulumi:"incidentConditionSummary"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionVisibility *string `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `IS`.
 	IncidentConditionalInactivity *string `pulumi:"incidentConditionalInactivity"`
 	// ex. 10 min, 1h, 3 days, 2 weeks
 	IncidentInactivityDuration *string `pulumi:"incidentInactivityDuration"`
 	// Value must be one of `test`, `testSub`, `example`, `exampleSub`, `normal`, `normalSub`, `backfilled`, `scheduled`, `scheduledSub`.
 	IncidentKinds []string `pulumi:"incidentKinds"`
-	// Value must be one off `ALL`, `ANY`, `NONE`.
+	// Value must be one of `ALL`, `ANY`, `NONE`.
 	IncidentPostMortemCondition *string `pulumi:"incidentPostMortemCondition"`
-	// [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentPostMortemConditionCause *string `pulumi:"incidentPostMortemConditionCause"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentPostMortemConditionStatus *string `pulumi:"incidentPostMortemConditionStatus"`
 	// Value must be one of `draft`, `published`.
 	IncidentPostMortemStatuses []string `pulumi:"incidentPostMortemStatuses"`
 	// Value must be one of `inTriage`, `started`, `detected`, `acknowledged`, `mitigated`, `resolved`, `closed`, `cancelled`, `scheduled`, `inProgress`, `completed`.
 	IncidentStatuses     []string `pulumi:"incidentStatuses"`
 	IncidentVisibilities []string `pulumi:"incidentVisibilities"`
-	// Value must be one off `postMortem`.
+	// Value must be one of `postMortem`.
 	TriggerType *string `pulumi:"triggerType"`
 	// Actions that trigger the workflow. One of custom*fields.\n\n.updated, post*mortem*created, post*mortem*updated, status*updated, slack_command
 	Triggers []string `pulumi:"triggers"`
@@ -11598,55 +11661,62 @@ type WorkflowPostMortemTriggerParamsInput interface {
 }
 
 type WorkflowPostMortemTriggerParamsArgs struct {
-	// Value must be one off `ALL`, `ANY`, `NONE`.
-	IncidentCondition               pulumi.StringPtrInput `pulumi:"incidentCondition"`
+	// Value must be one of `ALL`, `ANY`, `NONE`.
+	IncidentCondition pulumi.StringPtrInput `pulumi:"incidentCondition"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionAcknowledgedAt pulumi.StringPtrInput `pulumi:"incidentConditionAcknowledgedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionCause      pulumi.StringPtrInput `pulumi:"incidentConditionCause"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionCause pulumi.StringPtrInput `pulumi:"incidentConditionCause"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionDetectedAt pulumi.StringPtrInput `pulumi:"incidentConditionDetectedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionEnvironment pulumi.StringPtrInput `pulumi:"incidentConditionEnvironment"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionFunctionality pulumi.StringPtrInput `pulumi:"incidentConditionFunctionality"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionGroup pulumi.StringPtrInput `pulumi:"incidentConditionGroup"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentRoles pulumi.StringPtrInput `pulumi:"incidentConditionIncidentRoles"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionIncidentType pulumi.StringPtrInput `pulumi:"incidentConditionIncidentType"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionKind        pulumi.StringPtrInput `pulumi:"incidentConditionKind"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionKind pulumi.StringPtrInput `pulumi:"incidentConditionKind"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionMitigatedAt pulumi.StringPtrInput `pulumi:"incidentConditionMitigatedAt"`
-	IncidentConditionResolvedAt  pulumi.StringPtrInput `pulumi:"incidentConditionResolvedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionResolvedAt pulumi.StringPtrInput `pulumi:"incidentConditionResolvedAt"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionService pulumi.StringPtrInput `pulumi:"incidentConditionService"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionSeverity  pulumi.StringPtrInput `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionSeverity pulumi.StringPtrInput `pulumi:"incidentConditionSeverity"`
+	// Value must be one of `SET`, `UNSET`.
 	IncidentConditionStartedAt pulumi.StringPtrInput `pulumi:"incidentConditionStartedAt"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionStatus pulumi.StringPtrInput `pulumi:"incidentConditionStatus"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentConditionSubStatus pulumi.StringPtrInput `pulumi:"incidentConditionSubStatus"`
-	IncidentConditionSummary   pulumi.StringPtrInput `pulumi:"incidentConditionSummary"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
-	IncidentConditionVisibility   pulumi.StringPtrInput `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `SET`, `UNSET`.
+	IncidentConditionSummary pulumi.StringPtrInput `pulumi:"incidentConditionSummary"`
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	IncidentConditionVisibility pulumi.StringPtrInput `pulumi:"incidentConditionVisibility"`
+	// Value must be one of `IS`.
 	IncidentConditionalInactivity pulumi.StringPtrInput `pulumi:"incidentConditionalInactivity"`
 	// ex. 10 min, 1h, 3 days, 2 weeks
 	IncidentInactivityDuration pulumi.StringPtrInput `pulumi:"incidentInactivityDuration"`
 	// Value must be one of `test`, `testSub`, `example`, `exampleSub`, `normal`, `normalSub`, `backfilled`, `scheduled`, `scheduledSub`.
 	IncidentKinds pulumi.StringArrayInput `pulumi:"incidentKinds"`
-	// Value must be one off `ALL`, `ANY`, `NONE`.
+	// Value must be one of `ALL`, `ANY`, `NONE`.
 	IncidentPostMortemCondition pulumi.StringPtrInput `pulumi:"incidentPostMortemCondition"`
-	// [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentPostMortemConditionCause pulumi.StringPtrInput `pulumi:"incidentPostMortemConditionCause"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	IncidentPostMortemConditionStatus pulumi.StringPtrInput `pulumi:"incidentPostMortemConditionStatus"`
 	// Value must be one of `draft`, `published`.
 	IncidentPostMortemStatuses pulumi.StringArrayInput `pulumi:"incidentPostMortemStatuses"`
 	// Value must be one of `inTriage`, `started`, `detected`, `acknowledged`, `mitigated`, `resolved`, `closed`, `cancelled`, `scheduled`, `inProgress`, `completed`.
 	IncidentStatuses     pulumi.StringArrayInput `pulumi:"incidentStatuses"`
 	IncidentVisibilities pulumi.StringArrayInput `pulumi:"incidentVisibilities"`
-	// Value must be one off `postMortem`.
+	// Value must be one of `postMortem`.
 	TriggerType pulumi.StringPtrInput `pulumi:"triggerType"`
 	// Actions that trigger the workflow. One of custom*fields.\n\n.updated, post*mortem*created, post*mortem*updated, status*updated, slack_command
 	Triggers pulumi.StringArrayInput `pulumi:"triggers"`
@@ -11729,95 +11799,102 @@ func (o WorkflowPostMortemTriggerParamsOutput) ToWorkflowPostMortemTriggerParams
 	}).(WorkflowPostMortemTriggerParamsPtrOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentCondition }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionAcknowledgedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionAcknowledgedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionCause() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionCause }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionDetectedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionDetectedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionEnvironment() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionEnvironment }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionFunctionality() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionFunctionality }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionGroup() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionGroup }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionIncidentRoles() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionIncidentRoles }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionIncidentType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionIncidentType }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionKind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionKind }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionMitigatedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionMitigatedAt }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionResolvedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionResolvedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionService() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionService }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionSeverity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionSeverity }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionStartedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionStartedAt }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionStatus }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionSubStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionSubStatus }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionSummary() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionSummary }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionVisibility() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionVisibility }).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `IS`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentConditionalInactivity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentConditionalInactivity }).(pulumi.StringPtrOutput)
 }
@@ -11832,17 +11909,17 @@ func (o WorkflowPostMortemTriggerParamsOutput) IncidentKinds() pulumi.StringArra
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) []string { return v.IncidentKinds }).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentPostMortemCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentPostMortemCondition }).(pulumi.StringPtrOutput)
 }
 
-// [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentPostMortemConditionCause() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentPostMortemConditionCause }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsOutput) IncidentPostMortemConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.IncidentPostMortemConditionStatus }).(pulumi.StringPtrOutput)
 }
@@ -11861,7 +11938,7 @@ func (o WorkflowPostMortemTriggerParamsOutput) IncidentVisibilities() pulumi.Str
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) []string { return v.IncidentVisibilities }).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `postMortem`.
+// Value must be one of `postMortem`.
 func (o WorkflowPostMortemTriggerParamsOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPostMortemTriggerParams) *string { return v.TriggerType }).(pulumi.StringPtrOutput)
 }
@@ -11895,7 +11972,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) Elem() WorkflowPostMortemTrigg
 	}).(WorkflowPostMortemTriggerParamsOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -11905,6 +11982,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentCondition() pulumi.Str
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionAcknowledgedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -11914,7 +11992,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionAcknowledgedA
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionCause() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -11924,6 +12002,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionCause() pulum
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionDetectedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -11933,7 +12012,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionDetectedAt() 
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionEnvironment() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -11943,7 +12022,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionEnvironment()
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionFunctionality() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -11953,7 +12032,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionFunctionality
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionGroup() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -11963,7 +12042,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionGroup() pulum
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionIncidentRoles() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -11973,7 +12052,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionIncidentRoles
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionIncidentType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -11983,7 +12062,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionIncidentType(
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionKind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -11993,6 +12072,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionKind() pulumi
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionMitigatedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12002,6 +12082,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionMitigatedAt()
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionResolvedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12011,7 +12092,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionResolvedAt() 
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionService() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12021,7 +12102,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionService() pul
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionSeverity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12031,6 +12112,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionSeverity() pu
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionStartedAt() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12040,7 +12122,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionStartedAt() p
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12050,7 +12132,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionStatus() pulu
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionSubStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12060,6 +12142,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionSubStatus() p
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionSummary() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12069,7 +12152,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionSummary() pul
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionVisibility() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12079,6 +12162,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionVisibility() 
 	}).(pulumi.StringPtrOutput)
 }
 
+// Value must be one of `IS`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentConditionalInactivity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12108,7 +12192,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentKinds() pulumi.StringA
 	}).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentPostMortemCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12118,7 +12202,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentPostMortemCondition() 
 	}).(pulumi.StringPtrOutput)
 }
 
-// [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentPostMortemConditionCause() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12128,7 +12212,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentPostMortemConditionCau
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentPostMortemConditionStatus() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12167,7 +12251,7 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) IncidentVisibilities() pulumi.
 	}).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `postMortem`.
+// Value must be one of `postMortem`.
 func (o WorkflowPostMortemTriggerParamsPtrOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPostMortemTriggerParams) *string {
 		if v == nil {
@@ -12188,17 +12272,17 @@ func (o WorkflowPostMortemTriggerParamsPtrOutput) Triggers() pulumi.StringArrayO
 }
 
 type WorkflowPulseTriggerParams struct {
-	// Value must be one off `ALL`, `ANY`, `NONE`.
+	// Value must be one of `ALL`, `ANY`, `NONE`.
 	PulseCondition *string `pulumi:"pulseCondition"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	PulseConditionLabel *string `pulumi:"pulseConditionLabel"`
 	// Value must be one of true or false
 	PulseConditionLabelUseRegexp *bool `pulumi:"pulseConditionLabelUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	PulseConditionPayload *string `pulumi:"pulseConditionPayload"`
 	// Value must be one of true or false
 	PulseConditionPayloadUseRegexp *bool `pulumi:"pulseConditionPayloadUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	PulseConditionSource *string `pulumi:"pulseConditionSource"`
 	// Value must be one of true or false
 	PulseConditionSourceUseRegexp *bool    `pulumi:"pulseConditionSourceUseRegexp"`
@@ -12207,7 +12291,7 @@ type WorkflowPulseTriggerParams struct {
 	// You can use jsonpath syntax. eg: $.incident.teams[*]
 	PulseQueryPayload *string  `pulumi:"pulseQueryPayload"`
 	PulseSources      []string `pulumi:"pulseSources"`
-	// Value must be one off `pulse`.
+	// Value must be one of `pulse`.
 	TriggerType *string `pulumi:"triggerType"`
 	// Actions that trigger the workflow. Value must be one of `pulseCreated`.
 	Triggers []string `pulumi:"triggers"`
@@ -12225,17 +12309,17 @@ type WorkflowPulseTriggerParamsInput interface {
 }
 
 type WorkflowPulseTriggerParamsArgs struct {
-	// Value must be one off `ALL`, `ANY`, `NONE`.
+	// Value must be one of `ALL`, `ANY`, `NONE`.
 	PulseCondition pulumi.StringPtrInput `pulumi:"pulseCondition"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	PulseConditionLabel pulumi.StringPtrInput `pulumi:"pulseConditionLabel"`
 	// Value must be one of true or false
 	PulseConditionLabelUseRegexp pulumi.BoolPtrInput `pulumi:"pulseConditionLabelUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	PulseConditionPayload pulumi.StringPtrInput `pulumi:"pulseConditionPayload"`
 	// Value must be one of true or false
 	PulseConditionPayloadUseRegexp pulumi.BoolPtrInput `pulumi:"pulseConditionPayloadUseRegexp"`
-	// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+	// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 	PulseConditionSource pulumi.StringPtrInput `pulumi:"pulseConditionSource"`
 	// Value must be one of true or false
 	PulseConditionSourceUseRegexp pulumi.BoolPtrInput     `pulumi:"pulseConditionSourceUseRegexp"`
@@ -12244,7 +12328,7 @@ type WorkflowPulseTriggerParamsArgs struct {
 	// You can use jsonpath syntax. eg: $.incident.teams[*]
 	PulseQueryPayload pulumi.StringPtrInput   `pulumi:"pulseQueryPayload"`
 	PulseSources      pulumi.StringArrayInput `pulumi:"pulseSources"`
-	// Value must be one off `pulse`.
+	// Value must be one of `pulse`.
 	TriggerType pulumi.StringPtrInput `pulumi:"triggerType"`
 	// Actions that trigger the workflow. Value must be one of `pulseCreated`.
 	Triggers pulumi.StringArrayInput `pulumi:"triggers"`
@@ -12327,12 +12411,12 @@ func (o WorkflowPulseTriggerParamsOutput) ToWorkflowPulseTriggerParamsPtrOutputW
 	}).(WorkflowPulseTriggerParamsPtrOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowPulseTriggerParamsOutput) PulseCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPulseTriggerParams) *string { return v.PulseCondition }).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPulseTriggerParamsOutput) PulseConditionLabel() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPulseTriggerParams) *string { return v.PulseConditionLabel }).(pulumi.StringPtrOutput)
 }
@@ -12342,7 +12426,7 @@ func (o WorkflowPulseTriggerParamsOutput) PulseConditionLabelUseRegexp() pulumi.
 	return o.ApplyT(func(v WorkflowPulseTriggerParams) *bool { return v.PulseConditionLabelUseRegexp }).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPulseTriggerParamsOutput) PulseConditionPayload() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPulseTriggerParams) *string { return v.PulseConditionPayload }).(pulumi.StringPtrOutput)
 }
@@ -12352,7 +12436,7 @@ func (o WorkflowPulseTriggerParamsOutput) PulseConditionPayloadUseRegexp() pulum
 	return o.ApplyT(func(v WorkflowPulseTriggerParams) *bool { return v.PulseConditionPayloadUseRegexp }).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPulseTriggerParamsOutput) PulseConditionSource() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPulseTriggerParams) *string { return v.PulseConditionSource }).(pulumi.StringPtrOutput)
 }
@@ -12379,7 +12463,7 @@ func (o WorkflowPulseTriggerParamsOutput) PulseSources() pulumi.StringArrayOutpu
 	return o.ApplyT(func(v WorkflowPulseTriggerParams) []string { return v.PulseSources }).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `pulse`.
+// Value must be one of `pulse`.
 func (o WorkflowPulseTriggerParamsOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowPulseTriggerParams) *string { return v.TriggerType }).(pulumi.StringPtrOutput)
 }
@@ -12413,7 +12497,7 @@ func (o WorkflowPulseTriggerParamsPtrOutput) Elem() WorkflowPulseTriggerParamsOu
 	}).(WorkflowPulseTriggerParamsOutput)
 }
 
-// Value must be one off `ALL`, `ANY`, `NONE`.
+// Value must be one of `ALL`, `ANY`, `NONE`.
 func (o WorkflowPulseTriggerParamsPtrOutput) PulseCondition() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPulseTriggerParams) *string {
 		if v == nil {
@@ -12423,7 +12507,7 @@ func (o WorkflowPulseTriggerParamsPtrOutput) PulseCondition() pulumi.StringPtrOu
 	}).(pulumi.StringPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPulseTriggerParamsPtrOutput) PulseConditionLabel() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPulseTriggerParams) *string {
 		if v == nil {
@@ -12443,7 +12527,7 @@ func (o WorkflowPulseTriggerParamsPtrOutput) PulseConditionLabelUseRegexp() pulu
 	}).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPulseTriggerParamsPtrOutput) PulseConditionPayload() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPulseTriggerParams) *string {
 		if v == nil {
@@ -12463,7 +12547,7 @@ func (o WorkflowPulseTriggerParamsPtrOutput) PulseConditionPayloadUseRegexp() pu
 	}).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+// Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
 func (o WorkflowPulseTriggerParamsPtrOutput) PulseConditionSource() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPulseTriggerParams) *string {
 		if v == nil {
@@ -12520,7 +12604,7 @@ func (o WorkflowPulseTriggerParamsPtrOutput) PulseSources() pulumi.StringArrayOu
 	}).(pulumi.StringArrayOutput)
 }
 
-// Value must be one off `pulse`.
+// Value must be one of `pulse`.
 func (o WorkflowPulseTriggerParamsPtrOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowPulseTriggerParams) *string {
 		if v == nil {
@@ -12541,7 +12625,7 @@ func (o WorkflowPulseTriggerParamsPtrOutput) Triggers() pulumi.StringArrayOutput
 }
 
 type WorkflowSimpleTriggerParams struct {
-	// Value must be one off `simple`.
+	// Value must be one of `simple`.
 	TriggerType *string `pulumi:"triggerType"`
 	// Actions that trigger the workflow. Value must be one of `slackCommand`.
 	Triggers []string `pulumi:"triggers"`
@@ -12559,7 +12643,7 @@ type WorkflowSimpleTriggerParamsInput interface {
 }
 
 type WorkflowSimpleTriggerParamsArgs struct {
-	// Value must be one off `simple`.
+	// Value must be one of `simple`.
 	TriggerType pulumi.StringPtrInput `pulumi:"triggerType"`
 	// Actions that trigger the workflow. Value must be one of `slackCommand`.
 	Triggers pulumi.StringArrayInput `pulumi:"triggers"`
@@ -12642,7 +12726,7 @@ func (o WorkflowSimpleTriggerParamsOutput) ToWorkflowSimpleTriggerParamsPtrOutpu
 	}).(WorkflowSimpleTriggerParamsPtrOutput)
 }
 
-// Value must be one off `simple`.
+// Value must be one of `simple`.
 func (o WorkflowSimpleTriggerParamsOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v WorkflowSimpleTriggerParams) *string { return v.TriggerType }).(pulumi.StringPtrOutput)
 }
@@ -12676,7 +12760,7 @@ func (o WorkflowSimpleTriggerParamsPtrOutput) Elem() WorkflowSimpleTriggerParams
 	}).(WorkflowSimpleTriggerParamsOutput)
 }
 
-// Value must be one off `simple`.
+// Value must be one of `simple`.
 func (o WorkflowSimpleTriggerParamsPtrOutput) TriggerType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *WorkflowSimpleTriggerParams) *string {
 		if v == nil {
@@ -53771,12 +53855,40 @@ func (o GetIncidentTypesIncidentTypeArrayOutput) Index(i pulumi.IntInput) GetInc
 }
 
 type GetServicesService struct {
-	Color             string `pulumi:"color"`
-	Description       string `pulumi:"description"`
-	Id                string `pulumi:"id"`
-	Name              string `pulumi:"name"`
-	PublicDescription string `pulumi:"publicDescription"`
-	Slug              string `pulumi:"slug"`
+	AlertBroadcastChannel    map[string]string `pulumi:"alertBroadcastChannel"`
+	AlertBroadcastEnabled    bool              `pulumi:"alertBroadcastEnabled"`
+	AlertUrgencyId           string            `pulumi:"alertUrgencyId"`
+	AlertsEmailAddress       string            `pulumi:"alertsEmailAddress"`
+	AlertsEmailEnabled       bool              `pulumi:"alertsEmailEnabled"`
+	BackstageId              string            `pulumi:"backstageId"`
+	Color                    string            `pulumi:"color"`
+	CortexId                 string            `pulumi:"cortexId"`
+	Description              string            `pulumi:"description"`
+	EnvironmentIds           []string          `pulumi:"environmentIds"`
+	EscalationPolicyId       string            `pulumi:"escalationPolicyId"`
+	ExternalId               string            `pulumi:"externalId"`
+	GithubRepositoryBranch   string            `pulumi:"githubRepositoryBranch"`
+	GithubRepositoryName     string            `pulumi:"githubRepositoryName"`
+	GitlabRepositoryBranch   string            `pulumi:"gitlabRepositoryBranch"`
+	GitlabRepositoryName     string            `pulumi:"gitlabRepositoryName"`
+	Id                       string            `pulumi:"id"`
+	IncidentBroadcastChannel map[string]string `pulumi:"incidentBroadcastChannel"`
+	IncidentBroadcastEnabled bool              `pulumi:"incidentBroadcastEnabled"`
+	KubernetesDeploymentName string            `pulumi:"kubernetesDeploymentName"`
+	Name                     string            `pulumi:"name"`
+	NotifyEmails             []string          `pulumi:"notifyEmails"`
+	OpsgenieId               string            `pulumi:"opsgenieId"`
+	OwnerGroupIds            []string          `pulumi:"ownerGroupIds"`
+	OwnerUserIds             []string          `pulumi:"ownerUserIds"`
+	PagerdutyId              string            `pulumi:"pagerdutyId"`
+	Position                 int               `pulumi:"position"`
+	Properties               []string          `pulumi:"properties"`
+	PublicDescription        string            `pulumi:"publicDescription"`
+	ServiceIds               []string          `pulumi:"serviceIds"`
+	ServiceNowCiSysId        string            `pulumi:"serviceNowCiSysId"`
+	SlackAliases             []string          `pulumi:"slackAliases"`
+	SlackChannels            []string          `pulumi:"slackChannels"`
+	Slug                     string            `pulumi:"slug"`
 }
 
 // GetServicesServiceInput is an input type that accepts GetServicesServiceArgs and GetServicesServiceOutput values.
@@ -53791,12 +53903,40 @@ type GetServicesServiceInput interface {
 }
 
 type GetServicesServiceArgs struct {
-	Color             pulumi.StringInput `pulumi:"color"`
-	Description       pulumi.StringInput `pulumi:"description"`
-	Id                pulumi.StringInput `pulumi:"id"`
-	Name              pulumi.StringInput `pulumi:"name"`
-	PublicDescription pulumi.StringInput `pulumi:"publicDescription"`
-	Slug              pulumi.StringInput `pulumi:"slug"`
+	AlertBroadcastChannel    pulumi.StringMapInput   `pulumi:"alertBroadcastChannel"`
+	AlertBroadcastEnabled    pulumi.BoolInput        `pulumi:"alertBroadcastEnabled"`
+	AlertUrgencyId           pulumi.StringInput      `pulumi:"alertUrgencyId"`
+	AlertsEmailAddress       pulumi.StringInput      `pulumi:"alertsEmailAddress"`
+	AlertsEmailEnabled       pulumi.BoolInput        `pulumi:"alertsEmailEnabled"`
+	BackstageId              pulumi.StringInput      `pulumi:"backstageId"`
+	Color                    pulumi.StringInput      `pulumi:"color"`
+	CortexId                 pulumi.StringInput      `pulumi:"cortexId"`
+	Description              pulumi.StringInput      `pulumi:"description"`
+	EnvironmentIds           pulumi.StringArrayInput `pulumi:"environmentIds"`
+	EscalationPolicyId       pulumi.StringInput      `pulumi:"escalationPolicyId"`
+	ExternalId               pulumi.StringInput      `pulumi:"externalId"`
+	GithubRepositoryBranch   pulumi.StringInput      `pulumi:"githubRepositoryBranch"`
+	GithubRepositoryName     pulumi.StringInput      `pulumi:"githubRepositoryName"`
+	GitlabRepositoryBranch   pulumi.StringInput      `pulumi:"gitlabRepositoryBranch"`
+	GitlabRepositoryName     pulumi.StringInput      `pulumi:"gitlabRepositoryName"`
+	Id                       pulumi.StringInput      `pulumi:"id"`
+	IncidentBroadcastChannel pulumi.StringMapInput   `pulumi:"incidentBroadcastChannel"`
+	IncidentBroadcastEnabled pulumi.BoolInput        `pulumi:"incidentBroadcastEnabled"`
+	KubernetesDeploymentName pulumi.StringInput      `pulumi:"kubernetesDeploymentName"`
+	Name                     pulumi.StringInput      `pulumi:"name"`
+	NotifyEmails             pulumi.StringArrayInput `pulumi:"notifyEmails"`
+	OpsgenieId               pulumi.StringInput      `pulumi:"opsgenieId"`
+	OwnerGroupIds            pulumi.StringArrayInput `pulumi:"ownerGroupIds"`
+	OwnerUserIds             pulumi.StringArrayInput `pulumi:"ownerUserIds"`
+	PagerdutyId              pulumi.StringInput      `pulumi:"pagerdutyId"`
+	Position                 pulumi.IntInput         `pulumi:"position"`
+	Properties               pulumi.StringArrayInput `pulumi:"properties"`
+	PublicDescription        pulumi.StringInput      `pulumi:"publicDescription"`
+	ServiceIds               pulumi.StringArrayInput `pulumi:"serviceIds"`
+	ServiceNowCiSysId        pulumi.StringInput      `pulumi:"serviceNowCiSysId"`
+	SlackAliases             pulumi.StringArrayInput `pulumi:"slackAliases"`
+	SlackChannels            pulumi.StringArrayInput `pulumi:"slackChannels"`
+	Slug                     pulumi.StringInput      `pulumi:"slug"`
 }
 
 func (GetServicesServiceArgs) ElementType() reflect.Type {
@@ -53850,24 +53990,136 @@ func (o GetServicesServiceOutput) ToGetServicesServiceOutputWithContext(ctx cont
 	return o
 }
 
+func (o GetServicesServiceOutput) AlertBroadcastChannel() pulumi.StringMapOutput {
+	return o.ApplyT(func(v GetServicesService) map[string]string { return v.AlertBroadcastChannel }).(pulumi.StringMapOutput)
+}
+
+func (o GetServicesServiceOutput) AlertBroadcastEnabled() pulumi.BoolOutput {
+	return o.ApplyT(func(v GetServicesService) bool { return v.AlertBroadcastEnabled }).(pulumi.BoolOutput)
+}
+
+func (o GetServicesServiceOutput) AlertUrgencyId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.AlertUrgencyId }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) AlertsEmailAddress() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.AlertsEmailAddress }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) AlertsEmailEnabled() pulumi.BoolOutput {
+	return o.ApplyT(func(v GetServicesService) bool { return v.AlertsEmailEnabled }).(pulumi.BoolOutput)
+}
+
+func (o GetServicesServiceOutput) BackstageId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.BackstageId }).(pulumi.StringOutput)
+}
+
 func (o GetServicesServiceOutput) Color() pulumi.StringOutput {
 	return o.ApplyT(func(v GetServicesService) string { return v.Color }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) CortexId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.CortexId }).(pulumi.StringOutput)
 }
 
 func (o GetServicesServiceOutput) Description() pulumi.StringOutput {
 	return o.ApplyT(func(v GetServicesService) string { return v.Description }).(pulumi.StringOutput)
 }
 
+func (o GetServicesServiceOutput) EnvironmentIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v GetServicesService) []string { return v.EnvironmentIds }).(pulumi.StringArrayOutput)
+}
+
+func (o GetServicesServiceOutput) EscalationPolicyId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.EscalationPolicyId }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) ExternalId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.ExternalId }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) GithubRepositoryBranch() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.GithubRepositoryBranch }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) GithubRepositoryName() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.GithubRepositoryName }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) GitlabRepositoryBranch() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.GitlabRepositoryBranch }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) GitlabRepositoryName() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.GitlabRepositoryName }).(pulumi.StringOutput)
+}
+
 func (o GetServicesServiceOutput) Id() pulumi.StringOutput {
 	return o.ApplyT(func(v GetServicesService) string { return v.Id }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) IncidentBroadcastChannel() pulumi.StringMapOutput {
+	return o.ApplyT(func(v GetServicesService) map[string]string { return v.IncidentBroadcastChannel }).(pulumi.StringMapOutput)
+}
+
+func (o GetServicesServiceOutput) IncidentBroadcastEnabled() pulumi.BoolOutput {
+	return o.ApplyT(func(v GetServicesService) bool { return v.IncidentBroadcastEnabled }).(pulumi.BoolOutput)
+}
+
+func (o GetServicesServiceOutput) KubernetesDeploymentName() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.KubernetesDeploymentName }).(pulumi.StringOutput)
 }
 
 func (o GetServicesServiceOutput) Name() pulumi.StringOutput {
 	return o.ApplyT(func(v GetServicesService) string { return v.Name }).(pulumi.StringOutput)
 }
 
+func (o GetServicesServiceOutput) NotifyEmails() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v GetServicesService) []string { return v.NotifyEmails }).(pulumi.StringArrayOutput)
+}
+
+func (o GetServicesServiceOutput) OpsgenieId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.OpsgenieId }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) OwnerGroupIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v GetServicesService) []string { return v.OwnerGroupIds }).(pulumi.StringArrayOutput)
+}
+
+func (o GetServicesServiceOutput) OwnerUserIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v GetServicesService) []string { return v.OwnerUserIds }).(pulumi.StringArrayOutput)
+}
+
+func (o GetServicesServiceOutput) PagerdutyId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.PagerdutyId }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) Position() pulumi.IntOutput {
+	return o.ApplyT(func(v GetServicesService) int { return v.Position }).(pulumi.IntOutput)
+}
+
+func (o GetServicesServiceOutput) Properties() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v GetServicesService) []string { return v.Properties }).(pulumi.StringArrayOutput)
+}
+
 func (o GetServicesServiceOutput) PublicDescription() pulumi.StringOutput {
 	return o.ApplyT(func(v GetServicesService) string { return v.PublicDescription }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) ServiceIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v GetServicesService) []string { return v.ServiceIds }).(pulumi.StringArrayOutput)
+}
+
+func (o GetServicesServiceOutput) ServiceNowCiSysId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetServicesService) string { return v.ServiceNowCiSysId }).(pulumi.StringOutput)
+}
+
+func (o GetServicesServiceOutput) SlackAliases() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v GetServicesService) []string { return v.SlackAliases }).(pulumi.StringArrayOutput)
+}
+
+func (o GetServicesServiceOutput) SlackChannels() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v GetServicesService) []string { return v.SlackChannels }).(pulumi.StringArrayOutput)
 }
 
 func (o GetServicesServiceOutput) Slug() pulumi.StringOutput {

--- a/sdk/go/rootly/role.go
+++ b/sdk/go/rootly/role.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // Role can be imported using the `import` command.
@@ -19,9 +21,15 @@ import (
 // $ pulumi import rootly:index/role:Role primary a816421c-6ceb-481a-87c4-585e47451f24
 // ```
 //
+// You can also import by slug:
+//
+// ```sh
+// $ pulumi import rootly:index/role:Role primary my-role-slug
+// ```
+//
 // Or using an `import` block.
 //
-// Locate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.
+// Locate the resource id by listing roles through the API (`GET /v1/roles`), as role IDs are not visible in the web app.
 //
 // HCL can be generated from the import block using the `-generate-config-out` flag.
 //

--- a/sdk/go/rootly/schedule.go
+++ b/sdk/go/rootly/schedule.go
@@ -41,7 +41,7 @@ type Schedule struct {
 	Name pulumi.StringOutput `pulumi:"name"`
 	// The owning teams for this schedules.
 	OwnerGroupIds pulumi.StringArrayOutput `pulumi:"ownerGroupIds"`
-	// ID of user assigned as owner of the schedule
+	// ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.
 	OwnerUserId pulumi.IntOutput `pulumi:"ownerUserId"`
 	// Map must contain two fields, `id` and `name`. Synced slack channel of the schedule
 	SlackChannel pulumi.StringMapOutput `pulumi:"slackChannel"`
@@ -87,7 +87,7 @@ type scheduleState struct {
 	Name *string `pulumi:"name"`
 	// The owning teams for this schedules.
 	OwnerGroupIds []string `pulumi:"ownerGroupIds"`
-	// ID of user assigned as owner of the schedule
+	// ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.
 	OwnerUserId *int `pulumi:"ownerUserId"`
 	// Map must contain two fields, `id` and `name`. Synced slack channel of the schedule
 	SlackChannel map[string]string `pulumi:"slackChannel"`
@@ -104,7 +104,7 @@ type ScheduleState struct {
 	Name pulumi.StringPtrInput
 	// The owning teams for this schedules.
 	OwnerGroupIds pulumi.StringArrayInput
-	// ID of user assigned as owner of the schedule
+	// ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.
 	OwnerUserId pulumi.IntPtrInput
 	// Map must contain two fields, `id` and `name`. Synced slack channel of the schedule
 	SlackChannel pulumi.StringMapInput
@@ -125,7 +125,7 @@ type scheduleArgs struct {
 	Name *string `pulumi:"name"`
 	// The owning teams for this schedules.
 	OwnerGroupIds []string `pulumi:"ownerGroupIds"`
-	// ID of user assigned as owner of the schedule
+	// ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.
 	OwnerUserId *int `pulumi:"ownerUserId"`
 	// Map must contain two fields, `id` and `name`. Synced slack channel of the schedule
 	SlackChannel map[string]string `pulumi:"slackChannel"`
@@ -143,7 +143,7 @@ type ScheduleArgs struct {
 	Name pulumi.StringPtrInput
 	// The owning teams for this schedules.
 	OwnerGroupIds pulumi.StringArrayInput
-	// ID of user assigned as owner of the schedule
+	// ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.
 	OwnerUserId pulumi.IntPtrInput
 	// Map must contain two fields, `id` and `name`. Synced slack channel of the schedule
 	SlackChannel pulumi.StringMapInput
@@ -258,7 +258,7 @@ func (o ScheduleOutput) OwnerGroupIds() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Schedule) pulumi.StringArrayOutput { return v.OwnerGroupIds }).(pulumi.StringArrayOutput)
 }
 
-// ID of user assigned as owner of the schedule
+// ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.
 func (o ScheduleOutput) OwnerUserId() pulumi.IntOutput {
 	return o.ApplyT(func(v *Schedule) pulumi.IntOutput { return v.OwnerUserId }).(pulumi.IntOutput)
 }

--- a/sdk/go/rootly/secret.go
+++ b/sdk/go/rootly/secret.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // Secret can be imported using the `import` command.

--- a/sdk/go/rootly/statusPage.go
+++ b/sdk/go/rootly/statusPage.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // StatusPage can be imported using the `import` command.
@@ -40,6 +42,8 @@ type StatusPage struct {
 	AuthenticationMethod pulumi.StringPtrOutput `pulumi:"authenticationMethod"`
 	// Authentication password
 	AuthenticationPassword pulumi.StringOutput `pulumi:"authenticationPassword"`
+	// CNAME records mapping external domain names to their DNS target values. Populated asynchronously after setting external*domain*names.
+	CnameRecords pulumi.StringMapOutput `pulumi:"cnameRecords"`
 	// The description of the status page
 	Description pulumi.StringOutput  `pulumi:"description"`
 	Enabled     pulumi.BoolPtrOutput `pulumi:"enabled"`
@@ -136,6 +140,8 @@ type statusPageState struct {
 	AuthenticationMethod *string `pulumi:"authenticationMethod"`
 	// Authentication password
 	AuthenticationPassword *string `pulumi:"authenticationPassword"`
+	// CNAME records mapping external domain names to their DNS target values. Populated asynchronously after setting external*domain*names.
+	CnameRecords map[string]string `pulumi:"cnameRecords"`
 	// The description of the status page
 	Description *string `pulumi:"description"`
 	Enabled     *bool   `pulumi:"enabled"`
@@ -200,6 +206,8 @@ type StatusPageState struct {
 	AuthenticationMethod pulumi.StringPtrInput
 	// Authentication password
 	AuthenticationPassword pulumi.StringPtrInput
+	// CNAME records mapping external domain names to their DNS target values. Populated asynchronously after setting external*domain*names.
+	CnameRecords pulumi.StringMapInput
 	// The description of the status page
 	Description pulumi.StringPtrInput
 	Enabled     pulumi.BoolPtrInput
@@ -493,6 +501,11 @@ func (o StatusPageOutput) AuthenticationMethod() pulumi.StringPtrOutput {
 // Authentication password
 func (o StatusPageOutput) AuthenticationPassword() pulumi.StringOutput {
 	return o.ApplyT(func(v *StatusPage) pulumi.StringOutput { return v.AuthenticationPassword }).(pulumi.StringOutput)
+}
+
+// CNAME records mapping external domain names to their DNS target values. Populated asynchronously after setting external*domain*names.
+func (o StatusPageOutput) CnameRecords() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *StatusPage) pulumi.StringMapOutput { return v.CnameRecords }).(pulumi.StringMapOutput)
 }
 
 // The description of the status page

--- a/sdk/go/rootly/subStatus.go
+++ b/sdk/go/rootly/subStatus.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // SubStatus can be imported using the `import` command.

--- a/sdk/go/rootly/webhooksEndpoint.go
+++ b/sdk/go/rootly/webhooksEndpoint.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
 )
 
+// ## Example Usage
+//
 // ## Import
 //
 // WebhooksEndpoint can be imported using the `import` command.
@@ -33,7 +35,7 @@ type WebhooksEndpoint struct {
 	pulumi.CustomResourceState
 
 	Enabled pulumi.BoolPtrOutput `pulumi:"enabled"`
-	// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.
+	// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.
 	EventTypes pulumi.StringArrayOutput `pulumi:"eventTypes"`
 	// The name of the endpoint
 	Name pulumi.StringOutput `pulumi:"name"`
@@ -79,7 +81,7 @@ func GetWebhooksEndpoint(ctx *pulumi.Context,
 // Input properties used for looking up and filtering WebhooksEndpoint resources.
 type webhooksEndpointState struct {
 	Enabled *bool `pulumi:"enabled"`
-	// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.
+	// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.
 	EventTypes []string `pulumi:"eventTypes"`
 	// The name of the endpoint
 	Name *string `pulumi:"name"`
@@ -93,7 +95,7 @@ type webhooksEndpointState struct {
 
 type WebhooksEndpointState struct {
 	Enabled pulumi.BoolPtrInput
-	// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.
+	// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.
 	EventTypes pulumi.StringArrayInput
 	// The name of the endpoint
 	Name pulumi.StringPtrInput
@@ -111,7 +113,7 @@ func (WebhooksEndpointState) ElementType() reflect.Type {
 
 type webhooksEndpointArgs struct {
 	Enabled *bool `pulumi:"enabled"`
-	// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.
+	// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.
 	EventTypes []string `pulumi:"eventTypes"`
 	// The name of the endpoint
 	Name *string `pulumi:"name"`
@@ -126,7 +128,7 @@ type webhooksEndpointArgs struct {
 // The set of arguments for constructing a WebhooksEndpoint resource.
 type WebhooksEndpointArgs struct {
 	Enabled pulumi.BoolPtrInput
-	// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.
+	// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.
 	EventTypes pulumi.StringArrayInput
 	// The name of the endpoint
 	Name pulumi.StringPtrInput
@@ -229,7 +231,7 @@ func (o WebhooksEndpointOutput) Enabled() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *WebhooksEndpoint) pulumi.BoolPtrOutput { return v.Enabled }).(pulumi.BoolPtrOutput)
 }
 
-// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.
+// Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.
 func (o WebhooksEndpointOutput) EventTypes() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *WebhooksEndpoint) pulumi.StringArrayOutput { return v.EventTypes }).(pulumi.StringArrayOutput)
 }

--- a/sdk/nodejs/alertField.ts
+++ b/sdk/nodejs/alertField.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.AlertField can be imported using the `import` command.

--- a/sdk/nodejs/alertRoutingRule.ts
+++ b/sdk/nodejs/alertRoutingRule.ts
@@ -9,6 +9,8 @@ import * as utilities from "./utilities";
 /**
  * *Note: If you are an advanced alert routing user, you should use the Alert Routes resource/data source instead of this one. If you don't know whether you are an advanced alert routing user, please contact Rootly customer support.*
  *
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.AlertRoutingRule can be imported using the `import` command.

--- a/sdk/nodejs/alertUrgency.ts
+++ b/sdk/nodejs/alertUrgency.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.AlertUrgency can be imported using the `import` command.

--- a/sdk/nodejs/alertsSource.ts
+++ b/sdk/nodejs/alertsSource.ts
@@ -119,7 +119,7 @@ export class AlertsSource extends pulumi.CustomResource {
      */
     declare public readonly secret: pulumi.Output<string>;
     /**
-     * The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
+     * The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `dynatrace`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `awsSns`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
      */
     declare public readonly sourceType: pulumi.Output<string | undefined>;
     /**
@@ -249,7 +249,7 @@ export interface AlertsSourceState {
      */
     secret?: pulumi.Input<string | undefined>;
     /**
-     * The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
+     * The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `dynatrace`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `awsSns`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
      */
     sourceType?: pulumi.Input<string | undefined>;
     /**
@@ -323,7 +323,7 @@ export interface AlertsSourceArgs {
      */
     secret?: pulumi.Input<string | undefined>;
     /**
-     * The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
+     * The alert source type. Value must be one of `email`, `appDynamics`, `catchpoint`, `datadog`, `dynatrace`, `alertmanager`, `googleCloud`, `grafana`, `sentry`, `genericWebhook`, `cloudWatch`, `awsSns`, `checkly`, `azure`, `newRelic`, `splunk`, `chronosphere`, `appOptics`, `bugSnag`, `honeycomb`, `monteCarlo`, `nagios`, `prtg`.
      */
     sourceType?: pulumi.Input<string | undefined>;
     /**

--- a/sdk/nodejs/apiKey.ts
+++ b/sdk/nodejs/apiKey.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.ApiKey can be imported using the `import` command.

--- a/sdk/nodejs/catalog.ts
+++ b/sdk/nodejs/catalog.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.Catalog can be imported using the `import` command.

--- a/sdk/nodejs/catalogChecklistTemplate.ts
+++ b/sdk/nodejs/catalogChecklistTemplate.ts
@@ -7,6 +7,8 @@ import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.CatalogChecklistTemplate can be imported using the `import` command.

--- a/sdk/nodejs/catalogEntity.ts
+++ b/sdk/nodejs/catalogEntity.ts
@@ -7,6 +7,8 @@ import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.CatalogEntity can be imported using the `import` command.

--- a/sdk/nodejs/catalogProperty.ts
+++ b/sdk/nodejs/catalogProperty.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.CatalogProperty can be imported using the `import` command.

--- a/sdk/nodejs/cause.ts
+++ b/sdk/nodejs/cause.ts
@@ -7,6 +7,8 @@ import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.Cause can be imported using the `import` command.

--- a/sdk/nodejs/communicationsGroup.ts
+++ b/sdk/nodejs/communicationsGroup.ts
@@ -7,6 +7,8 @@ import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.CommunicationsGroup can be imported using the `import` command.

--- a/sdk/nodejs/communicationsStage.ts
+++ b/sdk/nodejs/communicationsStage.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.CommunicationsStage can be imported using the `import` command.

--- a/sdk/nodejs/communicationsTemplate.ts
+++ b/sdk/nodejs/communicationsTemplate.ts
@@ -7,6 +7,8 @@ import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.CommunicationsTemplate can be imported using the `import` command.

--- a/sdk/nodejs/communicationsType.ts
+++ b/sdk/nodejs/communicationsType.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.CommunicationsType can be imported using the `import` command.

--- a/sdk/nodejs/customField.ts
+++ b/sdk/nodejs/customField.ts
@@ -7,6 +7,8 @@ import * as utilities from "./utilities";
 /**
  * DEPRECATED: Please use `rootly.FormField` resource instead.
  *
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.CustomField can be imported using the `import` command.

--- a/sdk/nodejs/customFieldOption.ts
+++ b/sdk/nodejs/customFieldOption.ts
@@ -7,6 +7,8 @@ import * as utilities from "./utilities";
 /**
  * DEPRECATED: Please use `rootly.FormField` and `rootly.FormFieldOption` resources instead.
  *
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.CustomFieldOption can be imported using the `import` command.

--- a/sdk/nodejs/edgeConnector.ts
+++ b/sdk/nodejs/edgeConnector.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.EdgeConnector can be imported using the `import` command.

--- a/sdk/nodejs/functionality.ts
+++ b/sdk/nodejs/functionality.ts
@@ -74,7 +74,7 @@ export class Functionality extends pulumi.CustomResource {
     /**
      * Environments associated with this functionality
      */
-    declare public readonly environmentIds: pulumi.Output<string[] | undefined>;
+    declare public readonly environmentIds: pulumi.Output<string[]>;
     /**
      * The escalation policy id of the functionality
      */
@@ -102,11 +102,11 @@ export class Functionality extends pulumi.CustomResource {
     /**
      * Owner Teams associated with this functionality
      */
-    declare public readonly ownerGroupIds: pulumi.Output<string[] | undefined>;
+    declare public readonly ownerGroupIds: pulumi.Output<string[]>;
     /**
      * Owner Users associated with this functionality
      */
-    declare public readonly ownerUserIds: pulumi.Output<number[] | undefined>;
+    declare public readonly ownerUserIds: pulumi.Output<number[]>;
     /**
      * The PagerDuty service id associated to this functionality
      */
@@ -126,7 +126,7 @@ export class Functionality extends pulumi.CustomResource {
     /**
      * Services associated with this functionality
      */
-    declare public readonly serviceIds: pulumi.Output<string[] | undefined>;
+    declare public readonly serviceIds: pulumi.Output<string[]>;
     /**
      * The Service Now CI sys id associated to this functionality
      */

--- a/sdk/nodejs/heartbeat.ts
+++ b/sdk/nodejs/heartbeat.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.Heartbeat can be imported using the `import` command.

--- a/sdk/nodejs/incidentRole.ts
+++ b/sdk/nodejs/incidentRole.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.IncidentRole can be imported using the `import` command.

--- a/sdk/nodejs/incidentRoleTask.ts
+++ b/sdk/nodejs/incidentRoleTask.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.IncidentRoleTask can be imported using the `import` command.

--- a/sdk/nodejs/incidentSubStatus.ts
+++ b/sdk/nodejs/incidentSubStatus.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.IncidentSubStatus can be imported using the `import` command.

--- a/sdk/nodejs/incidentType.ts
+++ b/sdk/nodejs/incidentType.ts
@@ -7,6 +7,8 @@ import * as outputs from "./types/output";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.IncidentType can be imported using the `import` command.

--- a/sdk/nodejs/onCallRole.ts
+++ b/sdk/nodejs/onCallRole.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.OnCallRole can be imported using the `import` command.
@@ -13,9 +15,15 @@ import * as utilities from "./utilities";
  * $ pulumi import rootly:index/onCallRole:OnCallRole primary a816421c-6ceb-481a-87c4-585e47451f24
  * ```
  *
+ * You can also import by slug:
+ *
+ * ```sh
+ * $ pulumi import rootly:index/onCallRole:OnCallRole primary my-oncall-role-slug
+ * ```
+ *
  * Or using an `import` block.
  *
- * Locate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.
+ * Locate the resource id by listing on-call roles through the API (`GET /v1/on_call_roles`), as role IDs are not visible in the web app.
  *
  * HCL can be generated from the import block using the `-generate-config-out` flag.
  *

--- a/sdk/nodejs/onCallShadow.ts
+++ b/sdk/nodejs/onCallShadow.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.OnCallShadow can be imported using the `import` command.

--- a/sdk/nodejs/playbook.ts
+++ b/sdk/nodejs/playbook.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.Playbook can be imported using the `import` command.
@@ -54,7 +56,7 @@ export class Playbook extends pulumi.CustomResource {
     /**
      * The Environment IDs to attach to the incident
      */
-    declare public readonly environmentIds: pulumi.Output<string[] | undefined>;
+    declare public readonly environmentIds: pulumi.Output<string[]>;
     /**
      * The external url of the playbook
      */
@@ -62,23 +64,23 @@ export class Playbook extends pulumi.CustomResource {
     /**
      * The Functionality IDs to attach to the incident
      */
-    declare public readonly functionalityIds: pulumi.Output<string[] | undefined>;
+    declare public readonly functionalityIds: pulumi.Output<string[]>;
     /**
      * The Team IDs to attach to the incident
      */
-    declare public readonly groupIds: pulumi.Output<string[] | undefined>;
+    declare public readonly groupIds: pulumi.Output<string[]>;
     /**
      * The Incident Type IDs to attach to the incident
      */
-    declare public readonly incidentTypeIds: pulumi.Output<string[] | undefined>;
+    declare public readonly incidentTypeIds: pulumi.Output<string[]>;
     /**
      * The Service IDs to attach to the incident
      */
-    declare public readonly serviceIds: pulumi.Output<string[] | undefined>;
+    declare public readonly serviceIds: pulumi.Output<string[]>;
     /**
      * The Severity IDs to attach to the incident
      */
-    declare public readonly severityIds: pulumi.Output<string[] | undefined>;
+    declare public readonly severityIds: pulumi.Output<string[]>;
     /**
      * The summary of the playbook
      */

--- a/sdk/nodejs/playbookTask.ts
+++ b/sdk/nodejs/playbookTask.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.PlaybookTask can be imported using the `import` command.

--- a/sdk/nodejs/postMortemTemplate.ts
+++ b/sdk/nodejs/postMortemTemplate.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.PostMortemTemplate can be imported using the `import` command.

--- a/sdk/nodejs/role.ts
+++ b/sdk/nodejs/role.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.Role can be imported using the `import` command.
@@ -13,9 +15,15 @@ import * as utilities from "./utilities";
  * $ pulumi import rootly:index/role:Role primary a816421c-6ceb-481a-87c4-585e47451f24
  * ```
  *
+ * You can also import by slug:
+ *
+ * ```sh
+ * $ pulumi import rootly:index/role:Role primary my-role-slug
+ * ```
+ *
  * Or using an `import` block.
  *
- * Locate the resource id in the web app, or retrieve it by listing resources through the API if it's not visible in the web app.
+ * Locate the resource id by listing roles through the API (`GET /v1/roles`), as role IDs are not visible in the web app.
  *
  * HCL can be generated from the import block using the `-generate-config-out` flag.
  *

--- a/sdk/nodejs/schedule.ts
+++ b/sdk/nodejs/schedule.ts
@@ -70,7 +70,7 @@ export class Schedule extends pulumi.CustomResource {
      */
     declare public readonly ownerGroupIds: pulumi.Output<string[] | undefined>;
     /**
-     * ID of user assigned as owner of the schedule
+     * ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.
      */
     declare public readonly ownerUserId: pulumi.Output<number>;
     /**
@@ -138,7 +138,7 @@ export interface ScheduleState {
      */
     ownerGroupIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
-     * ID of user assigned as owner of the schedule
+     * ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.
      */
     ownerUserId?: pulumi.Input<number | undefined>;
     /**
@@ -172,7 +172,7 @@ export interface ScheduleArgs {
      */
     ownerGroupIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
-     * ID of user assigned as owner of the schedule
+     * ID of user assigned as owner of the schedule. Defaults to the API token's user if not specified.
      */
     ownerUserId?: pulumi.Input<number | undefined>;
     /**

--- a/sdk/nodejs/secret.ts
+++ b/sdk/nodejs/secret.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.Secret can be imported using the `import` command.

--- a/sdk/nodejs/service.ts
+++ b/sdk/nodejs/service.ts
@@ -94,7 +94,7 @@ export class Service extends pulumi.CustomResource {
     /**
      * Environments associated with this service
      */
-    declare public readonly environmentIds: pulumi.Output<string[] | undefined>;
+    declare public readonly environmentIds: pulumi.Output<string[]>;
     /**
      * The escalation policy id of the service
      */
@@ -146,11 +146,11 @@ export class Service extends pulumi.CustomResource {
     /**
      * Owner Teams associated with this service
      */
-    declare public readonly ownerGroupIds: pulumi.Output<string[] | undefined>;
+    declare public readonly ownerGroupIds: pulumi.Output<string[]>;
     /**
      * Owner Users associated with this service
      */
-    declare public readonly ownerUserIds: pulumi.Output<number[] | undefined>;
+    declare public readonly ownerUserIds: pulumi.Output<number[]>;
     /**
      * The PagerDuty service id associated to this service
      */
@@ -170,7 +170,7 @@ export class Service extends pulumi.CustomResource {
     /**
      * Services dependent on this service
      */
-    declare public readonly serviceIds: pulumi.Output<string[] | undefined>;
+    declare public readonly serviceIds: pulumi.Output<string[]>;
     /**
      * The Service Now CI sys id associated to this service
      */

--- a/sdk/nodejs/statusPage.ts
+++ b/sdk/nodejs/statusPage.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.StatusPage can be imported using the `import` command.
@@ -67,6 +69,10 @@ export class StatusPage extends pulumi.CustomResource {
      * Authentication password
      */
     declare public readonly authenticationPassword: pulumi.Output<string>;
+    /**
+     * CNAME records mapping external domain names to their DNS target values. Populated asynchronously after setting external*domain*names.
+     */
+    declare public /*out*/ readonly cnameRecords: pulumi.Output<{[key: string]: string}>;
     /**
      * The description of the status page
      */
@@ -190,6 +196,7 @@ export class StatusPage extends pulumi.CustomResource {
             resourceInputs["authenticationEnabled"] = state?.authenticationEnabled;
             resourceInputs["authenticationMethod"] = state?.authenticationMethod;
             resourceInputs["authenticationPassword"] = state?.authenticationPassword;
+            resourceInputs["cnameRecords"] = state?.cnameRecords;
             resourceInputs["description"] = state?.description;
             resourceInputs["enabled"] = state?.enabled;
             resourceInputs["externalDomainNames"] = state?.externalDomainNames;
@@ -253,6 +260,7 @@ export class StatusPage extends pulumi.CustomResource {
             resourceInputs["websitePrivacyUrl"] = args?.websitePrivacyUrl;
             resourceInputs["websiteSupportUrl"] = args?.websiteSupportUrl;
             resourceInputs["websiteUrl"] = args?.websiteUrl;
+            resourceInputs["cnameRecords"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(StatusPage.__pulumiType, name, resourceInputs, opts);
@@ -279,6 +287,10 @@ export interface StatusPageState {
      * Authentication password
      */
     authenticationPassword?: pulumi.Input<string | undefined>;
+    /**
+     * CNAME records mapping external domain names to their DNS target values. Populated asynchronously after setting external*domain*names.
+     */
+    cnameRecords?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
     /**
      * The description of the status page
      */

--- a/sdk/nodejs/subStatus.ts
+++ b/sdk/nodejs/subStatus.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.SubStatus can be imported using the `import` command.

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -1118,23 +1118,23 @@ export interface TeamSlackChannel {
 
 export interface WorkflowActionItemTriggerParams {
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     incidentActionItemCondition?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentActionItemConditionGroup?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentActionItemConditionKind?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentActionItemConditionPriority?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentActionItemConditionStatus?: pulumi.Input<string | undefined>;
     incidentActionItemGroupIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
@@ -1151,59 +1151,80 @@ export interface WorkflowActionItemTriggerParams {
      */
     incidentActionItemStatuses?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     incidentCondition?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionAcknowledgedAt?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionDetectedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionEnvironment?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionFunctionality?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionGroup?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentRoles?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentType?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionKind?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionMitigatedAt?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionResolvedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionService?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSeverity?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionStartedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionStatus?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSubStatus?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionSummary?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionVisibility?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `IS`.
+     */
     incidentConditionalInactivity?: pulumi.Input<string | undefined>;
     /**
      * ex. 10 min, 1h, 3 days, 2 weeks
@@ -1219,7 +1240,7 @@ export interface WorkflowActionItemTriggerParams {
     incidentStatuses?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     incidentVisibilities?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
-     * Value must be one off `actionItem`.
+     * Value must be one of `actionItem`.
      */
     triggerType?: pulumi.Input<string | undefined>;
     /**
@@ -1230,11 +1251,11 @@ export interface WorkflowActionItemTriggerParams {
 
 export interface WorkflowAlertTriggerParams {
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     alertCondition?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     alertConditionLabel?: pulumi.Input<string | undefined>;
     /**
@@ -1242,7 +1263,7 @@ export interface WorkflowAlertTriggerParams {
      */
     alertConditionLabelUseRegexp?: pulumi.Input<boolean | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     alertConditionPayload?: pulumi.Input<string | undefined>;
     /**
@@ -1250,7 +1271,7 @@ export interface WorkflowAlertTriggerParams {
      */
     alertConditionPayloadUseRegexp?: pulumi.Input<boolean | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     alertConditionSource?: pulumi.Input<string | undefined>;
     /**
@@ -1258,7 +1279,7 @@ export interface WorkflowAlertTriggerParams {
      */
     alertConditionSourceUseRegexp?: pulumi.Input<boolean | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     alertConditionStatus?: pulumi.Input<string | undefined>;
     /**
@@ -1266,7 +1287,7 @@ export interface WorkflowAlertTriggerParams {
      */
     alertConditionStatusUseRegexp?: pulumi.Input<boolean | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     alertConditionUrgency?: pulumi.Input<string | undefined>;
     alertFieldConditions?: pulumi.Input<pulumi.Input<inputs.WorkflowAlertTriggerParamsAlertFieldCondition>[] | undefined>;
@@ -1281,7 +1302,7 @@ export interface WorkflowAlertTriggerParams {
     alertStatuses?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     alertUrgencyIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
-     * Value must be one off `alert`.
+     * Value must be one of `alert`.
      */
     triggerType?: pulumi.Input<string | undefined>;
     /**
@@ -1318,63 +1339,84 @@ export interface WorkflowAlertTriggerParamsAlertPayloadConditionsCondition {
 
 export interface WorkflowIncidentTriggerParams {
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     incidentCondition?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionAcknowledgedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionCause?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionDetectedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionEnvironment?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionFunctionality?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionGroup?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentRoles?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentType?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionKind?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionMitigatedAt?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionResolvedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionService?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSeverity?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionStartedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionStatus?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSubStatus?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionSummary?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionVisibility?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `IS`.
+     */
     incidentConditionalInactivity?: pulumi.Input<string | undefined>;
     /**
      * ex. 10 min, 1h, 3 days, 2 weeks
@@ -1385,7 +1427,7 @@ export interface WorkflowIncidentTriggerParams {
      */
     incidentKinds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
-     * [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentPostMortemConditionCause?: pulumi.Input<string | undefined>;
     /**
@@ -1394,7 +1436,7 @@ export interface WorkflowIncidentTriggerParams {
     incidentStatuses?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     incidentVisibilities?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
-     * Value must be one off `incident`.
+     * Value must be one of `incident`.
      */
     triggerType?: pulumi.Input<string | undefined>;
     /**
@@ -1405,63 +1447,84 @@ export interface WorkflowIncidentTriggerParams {
 
 export interface WorkflowPostMortemTriggerParams {
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     incidentCondition?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionAcknowledgedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionCause?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionDetectedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionEnvironment?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionFunctionality?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionGroup?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentRoles?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentType?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionKind?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionMitigatedAt?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionResolvedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionService?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSeverity?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionStartedAt?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionStatus?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSubStatus?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionSummary?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionVisibility?: pulumi.Input<string | undefined>;
+    /**
+     * Value must be one of `IS`.
+     */
     incidentConditionalInactivity?: pulumi.Input<string | undefined>;
     /**
      * ex. 10 min, 1h, 3 days, 2 weeks
@@ -1472,15 +1535,15 @@ export interface WorkflowPostMortemTriggerParams {
      */
     incidentKinds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     incidentPostMortemCondition?: pulumi.Input<string | undefined>;
     /**
-     * [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentPostMortemConditionCause?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentPostMortemConditionStatus?: pulumi.Input<string | undefined>;
     /**
@@ -1493,7 +1556,7 @@ export interface WorkflowPostMortemTriggerParams {
     incidentStatuses?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     incidentVisibilities?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
-     * Value must be one off `postMortem`.
+     * Value must be one of `postMortem`.
      */
     triggerType?: pulumi.Input<string | undefined>;
     /**
@@ -1504,11 +1567,11 @@ export interface WorkflowPostMortemTriggerParams {
 
 export interface WorkflowPulseTriggerParams {
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     pulseCondition?: pulumi.Input<string | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     pulseConditionLabel?: pulumi.Input<string | undefined>;
     /**
@@ -1516,7 +1579,7 @@ export interface WorkflowPulseTriggerParams {
      */
     pulseConditionLabelUseRegexp?: pulumi.Input<boolean | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     pulseConditionPayload?: pulumi.Input<string | undefined>;
     /**
@@ -1524,7 +1587,7 @@ export interface WorkflowPulseTriggerParams {
      */
     pulseConditionPayloadUseRegexp?: pulumi.Input<boolean | undefined>;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     pulseConditionSource?: pulumi.Input<string | undefined>;
     /**
@@ -1539,7 +1602,7 @@ export interface WorkflowPulseTriggerParams {
     pulseQueryPayload?: pulumi.Input<string | undefined>;
     pulseSources?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
-     * Value must be one off `pulse`.
+     * Value must be one of `pulse`.
      */
     triggerType?: pulumi.Input<string | undefined>;
     /**
@@ -1550,7 +1613,7 @@ export interface WorkflowPulseTriggerParams {
 
 export interface WorkflowSimpleTriggerParams {
     /**
-     * Value must be one off `simple`.
+     * Value must be one of `simple`.
      */
     triggerType?: pulumi.Input<string | undefined>;
     /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -716,7 +716,7 @@ export interface EscalationPathRuleTimeBlock {
     /**
      * Whether this time block covers the entire day
      */
-    allDay: boolean;
+    allDay?: boolean;
     /**
      * Formatted as HH:MM
      */
@@ -724,11 +724,11 @@ export interface EscalationPathRuleTimeBlock {
     /**
      * Whether the time block applies on Friday
      */
-    friday: boolean;
+    friday?: boolean;
     /**
      * Whether the time block applies on Monday
      */
-    monday: boolean;
+    monday?: boolean;
     /**
      * Position of the time block
      */
@@ -736,7 +736,7 @@ export interface EscalationPathRuleTimeBlock {
     /**
      * Whether the time block applies on Saturday
      */
-    saturday: boolean;
+    saturday?: boolean;
     /**
      * Formatted as HH:MM
      */
@@ -744,19 +744,19 @@ export interface EscalationPathRuleTimeBlock {
     /**
      * Whether the time block applies on Sunday
      */
-    sunday: boolean;
+    sunday?: boolean;
     /**
      * Whether the time block applies on Thursday
      */
-    thursday: boolean;
+    thursday?: boolean;
     /**
      * Whether the time block applies on Tuesday
      */
-    tuesday: boolean;
+    tuesday?: boolean;
     /**
      * Whether the time block applies on Wednesday
      */
-    wednesday: boolean;
+    wednesday?: boolean;
 }
 
 export interface EscalationPathTimeRestriction {
@@ -889,11 +889,39 @@ export interface GetIncidentTypesIncidentType {
 }
 
 export interface GetServicesService {
+    alertBroadcastChannel: {[key: string]: string};
+    alertBroadcastEnabled: boolean;
+    alertUrgencyId: string;
+    alertsEmailAddress: string;
+    alertsEmailEnabled: boolean;
+    backstageId: string;
     color: string;
+    cortexId: string;
     description: string;
+    environmentIds: string[];
+    escalationPolicyId: string;
+    externalId: string;
+    githubRepositoryBranch: string;
+    githubRepositoryName: string;
+    gitlabRepositoryBranch: string;
+    gitlabRepositoryName: string;
     id: string;
+    incidentBroadcastChannel: {[key: string]: string};
+    incidentBroadcastEnabled: boolean;
+    kubernetesDeploymentName: string;
     name: string;
+    notifyEmails: string[];
+    opsgenieId: string;
+    ownerGroupIds: string[];
+    ownerUserIds: string[];
+    pagerdutyId: string;
+    position: number;
+    properties: string[];
     publicDescription: string;
+    serviceIds: string[];
+    serviceNowCiSysId: string;
+    slackAliases: string[];
+    slackChannels: string[];
     slug: string;
 }
 
@@ -1202,23 +1230,23 @@ export interface TeamSlackChannel {
 
 export interface WorkflowActionItemTriggerParams {
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     incidentActionItemCondition?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentActionItemConditionGroup?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentActionItemConditionKind?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentActionItemConditionPriority?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentActionItemConditionStatus?: string;
     incidentActionItemGroupIds: string[];
@@ -1235,59 +1263,80 @@ export interface WorkflowActionItemTriggerParams {
      */
     incidentActionItemStatuses: string[];
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     incidentCondition?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionAcknowledgedAt: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionDetectedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionEnvironment?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionFunctionality?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionGroup?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentRoles?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentType?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionKind?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionMitigatedAt: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionResolvedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionService?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSeverity?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionStartedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionStatus?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSubStatus?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionSummary: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionVisibility?: string;
+    /**
+     * Value must be one of `IS`.
+     */
     incidentConditionalInactivity: string;
     /**
      * ex. 10 min, 1h, 3 days, 2 weeks
@@ -1303,7 +1352,7 @@ export interface WorkflowActionItemTriggerParams {
     incidentStatuses: string[];
     incidentVisibilities: string[];
     /**
-     * Value must be one off `actionItem`.
+     * Value must be one of `actionItem`.
      */
     triggerType?: string;
     /**
@@ -1314,11 +1363,11 @@ export interface WorkflowActionItemTriggerParams {
 
 export interface WorkflowAlertTriggerParams {
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     alertCondition?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     alertConditionLabel?: string;
     /**
@@ -1326,7 +1375,7 @@ export interface WorkflowAlertTriggerParams {
      */
     alertConditionLabelUseRegexp: boolean;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     alertConditionPayload?: string;
     /**
@@ -1334,7 +1383,7 @@ export interface WorkflowAlertTriggerParams {
      */
     alertConditionPayloadUseRegexp: boolean;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     alertConditionSource?: string;
     /**
@@ -1342,7 +1391,7 @@ export interface WorkflowAlertTriggerParams {
      */
     alertConditionSourceUseRegexp: boolean;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     alertConditionStatus?: string;
     /**
@@ -1350,7 +1399,7 @@ export interface WorkflowAlertTriggerParams {
      */
     alertConditionStatusUseRegexp: boolean;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     alertConditionUrgency?: string;
     alertFieldConditions: outputs.WorkflowAlertTriggerParamsAlertFieldCondition[];
@@ -1365,7 +1414,7 @@ export interface WorkflowAlertTriggerParams {
     alertStatuses: string[];
     alertUrgencyIds: string[];
     /**
-     * Value must be one off `alert`.
+     * Value must be one of `alert`.
      */
     triggerType?: string;
     /**
@@ -1402,63 +1451,84 @@ export interface WorkflowAlertTriggerParamsAlertPayloadConditionsCondition {
 
 export interface WorkflowIncidentTriggerParams {
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     incidentCondition?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionAcknowledgedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionCause?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionDetectedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionEnvironment?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionFunctionality?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionGroup?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentRoles?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentType?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionKind?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionMitigatedAt: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionResolvedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionService?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSeverity?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionStartedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionStatus?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSubStatus?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionSummary: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionVisibility?: string;
+    /**
+     * Value must be one of `IS`.
+     */
     incidentConditionalInactivity: string;
     /**
      * ex. 10 min, 1h, 3 days, 2 weeks
@@ -1469,7 +1539,7 @@ export interface WorkflowIncidentTriggerParams {
      */
     incidentKinds: string[];
     /**
-     * [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentPostMortemConditionCause?: string;
     /**
@@ -1478,7 +1548,7 @@ export interface WorkflowIncidentTriggerParams {
     incidentStatuses: string[];
     incidentVisibilities: string[];
     /**
-     * Value must be one off `incident`.
+     * Value must be one of `incident`.
      */
     triggerType?: string;
     /**
@@ -1489,63 +1559,84 @@ export interface WorkflowIncidentTriggerParams {
 
 export interface WorkflowPostMortemTriggerParams {
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     incidentCondition?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionAcknowledgedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionCause?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionDetectedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionEnvironment?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionFunctionality?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionGroup?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentRoles?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionIncidentType?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionKind?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionMitigatedAt: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionResolvedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionService?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSeverity?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionStartedAt: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionStatus?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionSubStatus?: string;
+    /**
+     * Value must be one of `SET`, `UNSET`.
+     */
     incidentConditionSummary: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentConditionVisibility?: string;
+    /**
+     * Value must be one of `IS`.
+     */
     incidentConditionalInactivity: string;
     /**
      * ex. 10 min, 1h, 3 days, 2 weeks
@@ -1556,15 +1647,15 @@ export interface WorkflowPostMortemTriggerParams {
      */
     incidentKinds: string[];
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     incidentPostMortemCondition?: string;
     /**
-     * [DEPRECATED] Use incident*condition*cause instead. Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * [DEPRECATED] Use incident*condition*cause instead. Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentPostMortemConditionCause?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     incidentPostMortemConditionStatus?: string;
     /**
@@ -1577,7 +1668,7 @@ export interface WorkflowPostMortemTriggerParams {
     incidentStatuses: string[];
     incidentVisibilities: string[];
     /**
-     * Value must be one off `postMortem`.
+     * Value must be one of `postMortem`.
      */
     triggerType?: string;
     /**
@@ -1588,11 +1679,11 @@ export interface WorkflowPostMortemTriggerParams {
 
 export interface WorkflowPulseTriggerParams {
     /**
-     * Value must be one off `ALL`, `ANY`, `NONE`.
+     * Value must be one of `ALL`, `ANY`, `NONE`.
      */
     pulseCondition?: string;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     pulseConditionLabel?: string;
     /**
@@ -1600,7 +1691,7 @@ export interface WorkflowPulseTriggerParams {
      */
     pulseConditionLabelUseRegexp: boolean;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     pulseConditionPayload?: string;
     /**
@@ -1608,7 +1699,7 @@ export interface WorkflowPulseTriggerParams {
      */
     pulseConditionPayloadUseRegexp: boolean;
     /**
-     * Value must be one off `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
+     * Value must be one of `IS`, `IS NOT`, `ANY`, `CONTAINS`, `CONTAINS_ALL`, `CONTAINS_NONE`, `NONE`, `SET`, `UNSET`.
      */
     pulseConditionSource?: string;
     /**
@@ -1623,7 +1714,7 @@ export interface WorkflowPulseTriggerParams {
     pulseQueryPayload: string;
     pulseSources: string[];
     /**
-     * Value must be one off `pulse`.
+     * Value must be one of `pulse`.
      */
     triggerType?: string;
     /**
@@ -1634,7 +1725,7 @@ export interface WorkflowPulseTriggerParams {
 
 export interface WorkflowSimpleTriggerParams {
     /**
-     * Value must be one off `simple`.
+     * Value must be one of `simple`.
      */
     triggerType?: string;
     /**

--- a/sdk/nodejs/webhooksEndpoint.ts
+++ b/sdk/nodejs/webhooksEndpoint.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
+ * ## Example Usage
+ *
  * ## Import
  *
  * rootly.WebhooksEndpoint can be imported using the `import` command.
@@ -53,7 +55,7 @@ export class WebhooksEndpoint extends pulumi.CustomResource {
 
     declare public readonly enabled: pulumi.Output<boolean | undefined>;
     /**
-     * Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.
+     * Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.
      */
     declare public readonly eventTypes: pulumi.Output<string[] | undefined>;
     /**
@@ -115,7 +117,7 @@ export class WebhooksEndpoint extends pulumi.CustomResource {
 export interface WebhooksEndpointState {
     enabled?: pulumi.Input<boolean | undefined>;
     /**
-     * Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.
+     * Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.
      */
     eventTypes?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
@@ -142,7 +144,7 @@ export interface WebhooksEndpointState {
 export interface WebhooksEndpointArgs {
     enabled?: pulumi.Input<boolean | undefined>;
     /**
-     * Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`.
+     * Value must be one of `incident.created`, `incident.updated`, `incident.in_triage`, `incident.mitigated`, `incident.resolved`, `incident.cancelled`, `incident.deleted`, `incident.scheduled.created`, `incident.scheduled.updated`, `incident.scheduled.in_progress`, `incident.scheduled.completed`, `incident.scheduled.deleted`, `incident_post_mortem.created`, `incident_post_mortem.updated`, `incident_post_mortem.published`, `incident_post_mortem.deleted`, `incident_status_page_event.created`, `incident_status_page_event.updated`, `incident_status_page_event.deleted`, `incident_event.created`, `incident_event.updated`, `incident_event.deleted`, `alert.created`, `pulse.created`, `genius_workflow_run.queued`, `genius_workflow_run.started`, `genius_workflow_run.completed`, `genius_workflow_run.failed`, `genius_workflow_run.canceled`, `audit_log.created`.
      */
     eventTypes?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**


### PR DESCRIPTION
## Summary
- Migrate Go module path from `terraform-provider-rootly/v2` to `/v5` — upstream fixed their `go.mod` to declare the correct major version
- Update `make update_provider` to use `v5@latest` instead of `v2@master`
- Pin to tagged release `v5.15.0` instead of pseudo-version from master
- Regenerate NodeJS and Go SDKs

## What changed
- `provider/resources.go`: import path `/v2` → `/v5`, `TFProviderModuleVersion: "v5"`
- `provider/go.mod`: `terraform-provider-rootly/v5 v5.15.0`
- `Makefile`: `update_provider` uses `/v5@latest`
- Schema and SDK changes from v5.15.0 (minor property updates across 77 files)

## Test plan
- [x] `make development` passes (provider + lint + NodeJS/Go SDKs)
- [ ] CI builds successfully