### PR TITLE
fix(sdk/go): declare /v3 module path, bump go directive, tag nested submodule

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -110,14 +110,22 @@ check_git_status() {
 create_and_push_tag() {
     local version="$1"
     local tag="v$version"
-    
+    local sdk_tag="sdk/v$version"
+
     print_info "Creating git tag: $tag"
     git tag -a "$tag" -m "Release $tag"
-    
-    print_info "Pushing tag to origin..."
-    git push origin "$tag"
-    
-    print_success "Tag $tag created and pushed successfully!"
+
+    # The Go SDK lives in ./sdk with its own go.mod. For consumers to fetch
+    # it via `go get github.com/rootlyhq/pulumi-rootly/sdk/v<major>`, Go
+    # requires a tag named `sdk/v<version>` pointing at the same commit
+    # (semantic import versioning for nested modules).
+    print_info "Creating Go submodule tag: $sdk_tag"
+    git tag -a "$sdk_tag" -m "Release $sdk_tag"
+
+    print_info "Pushing tags to origin..."
+    git push origin "$tag" "$sdk_tag"
+
+    print_success "Tags $tag and $sdk_tag created and pushed successfully!"
 }
 
 # Function to show version information

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,3 +1,3 @@
-module github.com/rootlyhq/pulumi-rootly/sdk
+module github.com/rootlyhq/pulumi-rootly/sdk/v3
 
-go 1.17
+go 1.18


### PR DESCRIPTION
## Problem

The SDK's generated Go code imports paths like:

```go
"github.com/rootlyhq/pulumi-rootly/sdk/v3/go/rootly/internal"
```

These paths are emitted by `tfbridge` because the provider sets the import base path to include the major-version suffix at [`provider/resources.go:170-176`](https://github.com/rootlyhq/pulumi-rootly/blob/master/provider/resources.go#L170-L176):

```go
Golang: &tfbridge.GolangInfo{
    ImportBasePath: path.Join(
        "github.com/rootlyhq/pulumi-rootly/sdk/",
        tfbridge.GetModuleMajorVersion(version.Version), // "v3" at v3.x.x
        "go",
        mainPkg,
    ),
    ...
},
```

But `sdk/go.mod` declares the module **without** the `/v3` suffix:

```
module github.com/rootlyhq/pulumi-rootly/sdk
```

This violates Go's [semantic import versioning](https://go.dev/ref/mod#major-version-suffixes) rule that any module at major version 2+ must declare a path ending in `/vN`. The result: **the SDK is unconsumable as a Go module dependency at v2+**.

### Demonstration

```console
$ go get github.com/rootlyhq/pulumi-rootly/sdk/v3@v3.3.0
go: module github.com/rootlyhq/pulumi-rootly@v3.3.0+incompatible found,
    but does not contain package github.com/rootlyhq/pulumi-rootly/sdk
```

Go can't locate a module declaring `/sdk/v3`. The `+incompatible` fallback (which would let v3.x.x resolve against a module declaring `.../sdk`) doesn't apply here because the SDK is a [nested module](https://go.dev/ref/mod#vcs-version) (its own `go.mod` inside `sdk/`), and Go's `+incompatible` fallback only resolves against root-level modules.

### Downstream impact

Today, anyone wanting to use this SDK from Go has to either:
- **Vendor the SDK locally** with a stub `go.mod` + `replace` directive, or
- **Depend on a fork** that patches the module path

There's also a **second**, independent problem exposed once the module path is fixed: `sdk/go.mod` declares `go 1.17`, but the generated SDK already uses the `any` predeclared identifier (introduced in Go 1.18) at `sdk/go/rootly/internal/pulumiUtilities.go:132`. Building the SDK as published fails with:

```
predeclared any requires go1.18 or later (-lang was set to go1.17; check go.mod)
```

So the SDK isn't just unresolvable — even if a consumer worked around the path issue, the published code doesn't compile against its own declared Go version.

Compare with peer providers that ship a properly-versioned Go module — `pulumi-aws`, `pulumi-gcp`, `pulumi-kubernetes`, etc. — where a one-line `require` is all that's needed:

```go
require github.com/pulumi/pulumi-aws/sdk/v6 v6.40.0    // ✓ works
require github.com/rootlyhq/pulumi-rootly/sdk/v3 v3.3.0 // ✗ unresolvable today
```

## After this PR

A future release (e.g. `v3.4.0`) will push both `v3.4.0` and `sdk/v3.4.0`. Go consumers can then use:

```go
require github.com/rootlyhq/pulumi-rootly/sdk/v3 v3.4.0
```